### PR TITLE
Add password complexity validation

### DIFF
--- a/app/javascript/controllers/password_complexity_controller.js
+++ b/app/javascript/controllers/password_complexity_controller.js
@@ -1,0 +1,50 @@
+import { Controller } from "@hotwired/stimulus"
+
+const RULES = [
+  { test: v => v.length >= 8, label: "At least 8 characters" },
+  { test: v => /[A-Z]/.test(v), label: "One uppercase letter" },
+  { test: v => /[a-z]/.test(v), label: "One lowercase letter" },
+  { test: v => /\d/.test(v), label: "One digit" },
+  { test: v => /[^A-Za-z0-9]/.test(v), label: "One special character" },
+]
+
+export default class extends Controller {
+  static targets = ["input"]
+
+  connect() {
+    this.checklist = document.createElement("ul")
+    this.checklist.className = "text-sm mt-2 space-y-1 hidden"
+
+    this.items = RULES.map(rule => {
+      const li = document.createElement("li")
+      li.className = "flex items-center gap-1.5 text-base-content/50"
+      li.innerHTML = `<iconify-icon icon="lucide:circle" width="14"></iconify-icon> ${rule.label}`
+      this.checklist.appendChild(li)
+      return { li, rule }
+    })
+
+    this.inputTarget.parentNode.appendChild(this.checklist)
+  }
+
+  validate() {
+    const value = this.inputTarget.value
+
+    if (value.length === 0) {
+      this.checklist.classList.add("hidden")
+      return
+    }
+
+    this.checklist.classList.remove("hidden")
+
+    this.items.forEach(({ li, rule }) => {
+      const pass = rule.test(value)
+      li.className = pass
+        ? "flex items-center gap-1.5 text-success"
+        : "flex items-center gap-1.5 text-base-content/50"
+      li.querySelector("iconify-icon").setAttribute(
+        "icon",
+        pass ? "lucide:check-circle" : "lucide:circle"
+      )
+    })
+  }
+}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,6 +42,8 @@ class User < ApplicationRecord
   devise :invitable, :database_authenticatable,
          :registerable, :rememberable, :validatable, :omniauthable
 
+  validates :password, password_complexity: true, if: :password_required?
+
   has_one_attached :avatar
   has_person_name
 

--- a/app/validators/password_complexity_validator.rb
+++ b/app/validators/password_complexity_validator.rb
@@ -1,0 +1,10 @@
+class PasswordComplexityValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return if value.blank?
+
+    record.errors.add(attribute, "must include at least one uppercase letter") unless value.match?(/[A-Z]/)
+    record.errors.add(attribute, "must include at least one lowercase letter") unless value.match?(/[a-z]/)
+    record.errors.add(attribute, "must include at least one digit") unless value.match?(/\d/)
+    record.errors.add(attribute, "must include at least one special character") unless value.match?(/[^A-Za-z0-9]/)
+  end
+end

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -6,11 +6,9 @@
       <%= render "devise/shared/error_messages", resource: resource %>
       <%= f.hidden_field :reset_password_token %>
 
-      <div class="mb-3">
-        <%= f.password_field :password, autofocus: true, autocomplete: "off", class: 'form-control', placeholder: "Password" %>
-        <% if @minimum_password_length %>
-          <p class="text-muted"><small><%= @minimum_password_length %> characters minimum</small></p>
-        <% end %>
+      <div class="mb-3" data-controller="password-complexity">
+        <%= f.password_field :password, autofocus: true, autocomplete: "off", class: 'form-control', placeholder: "Password",
+            data: { password_complexity_target: "input", action: "input->password-complexity#validate" } %>
       </div>
 
       <div class="mb-3">

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -40,8 +40,9 @@
         <p class="text-sm text-base-content/70">You signed in with <strong>GitHub</strong>. Your password is managed by your authentication provider.</p>
       <% else %>
         <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, data: { turbo: false } }) do |f| %>
-          <div class="mb-3">
-            <%= f.password_field :password, class: 'input input-bordered w-full focus:outline-offset-0', placeholder: "New password", autocomplete: "new-password" %>
+          <div class="mb-3" data-controller="password-complexity">
+            <%= f.password_field :password, class: 'input input-bordered w-full focus:outline-offset-0', placeholder: "New password", autocomplete: "new-password",
+                data: { password_complexity_target: "input", action: "input->password-complexity#validate" } %>
           </div>
           <div class="mb-3">
             <%= f.password_field :password_confirmation, class: 'input input-bordered w-full focus:outline-offset-0', placeholder: "Confirm new password", autocomplete: "new-password" %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -37,11 +37,12 @@
           <%= f.email_field :email, autocomplete: "username", placeholder: true, inputmode: "email", class: "input input-bordered w-full" %>
         </div>
 
-        <div class="form-control">
+        <div class="form-control" data-controller="password-complexity">
           <%= f.label :password, class: "label" do %>
             <span class="label-text">Password</span>
           <% end %>
-          <%= f.password_field :password, autocomplete: "new-password", placeholder: true, class: "input input-bordered w-full" %>
+          <%= f.password_field :password, autocomplete: "new-password", placeholder: true, class: "input input-bordered w-full",
+              data: { password_complexity_target: "input", action: "input->password-complexity#validate" } %>
         </div>
 
         <div class="form-control mt-6">

--- a/app/views/local/onboarding/_normal.html.erb
+++ b/app/views/local/onboarding/_normal.html.erb
@@ -34,7 +34,7 @@
           data: { email_validation_target: "input", action: "input->email-validation#validate" },
         ) %>
       </div>
-      <div class="form-group" data-controller="toggle-password">
+      <div class="form-group" data-controller="toggle-password password-complexity">
         <%= form.label :password, "Password" %>
         <div class="flex items-center">
           <%= form.password_field(
@@ -43,7 +43,7 @@
             name: "user[password]",
             class: "input input-bordered w-full",
             required: true,
-            data: { toggle_password_target: "input" },
+            data: { toggle_password_target: "input", password_complexity_target: "input", action: "input->password-complexity#validate" },
           ) %>
           <button type="button" class="btn btn-outline" data-action="toggle-password#toggle">
             <iconify-icon data-toggle-password-target="icon" icon="mdi:eye"></iconify-icon>

--- a/app/views/local/onboarding/_portainer.html.erb
+++ b/app/views/local/onboarding/_portainer.html.erb
@@ -33,7 +33,7 @@
           data: { email_validation_target: "input", action: "input->email-validation#validate" },
         ) %>
       </div>
-      <div class="form-group" data-controller="toggle-password">
+      <div class="form-group" data-controller="toggle-password password-complexity">
         <%= form.label :password, "Password" %>
         <div class="flex items-center">
           <%= form.password_field(
@@ -42,7 +42,7 @@
             name: "user[password]",
             class: "input input-bordered w-full",
             required: true,
-            data: { toggle_password_target: "input" },
+            data: { toggle_password_target: "input", password_complexity_target: "input", action: "input->password-complexity#validate" },
           ) %>
           <button type="button" class="btn btn-outline" data-action="toggle-password#toggle">
             <iconify-icon data-toggle-password-target="icon" icon="mdi:eye"></iconify-icon>

--- a/app/views/local/onboarding/_rancher.html.erb
+++ b/app/views/local/onboarding/_rancher.html.erb
@@ -33,7 +33,7 @@
           data: { email_validation_target: "input", action: "input->email-validation#validate" },
         ) %>
       </div>
-      <div class="form-group" data-controller="toggle-password">
+      <div class="form-group" data-controller="toggle-password password-complexity">
         <%= form.label :password, "Password" %>
         <div class="flex items-center">
           <%= form.password_field(
@@ -42,7 +42,7 @@
             name: "user[password]",
             class: "input input-bordered w-full",
             required: true,
-            data: { toggle_password_target: "input" },
+            data: { toggle_password_target: "input", password_complexity_target: "input", action: "input->password-complexity#validate" },
           ) %>
           <button type="button" class="btn btn-outline" data-action="toggle-password#toggle">
             <iconify-icon data-toggle-password-target="icon" icon="mdi:eye"></iconify-icon>

--- a/app/views/password_change/show.html.erb
+++ b/app/views/password_change/show.html.erb
@@ -24,11 +24,12 @@
           </label>
         </div>
 
-        <div class="form-control">
+        <div class="form-control" data-controller="password-complexity">
           <%= f.label :password, "New Password", class: "label" do %>
             <span class="label-text">New Password</span>
           <% end %>
-          <%= f.password_field :password, autocomplete: "new-password", class: "input input-bordered w-full", required: true %>
+          <%= f.password_field :password, autocomplete: "new-password", class: "input input-bordered w-full", required: true,
+              data: { password_complexity_target: "input", action: "input->password-complexity#validate" } %>
         </div>
 
         <div class="form-control">

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -227,7 +227,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 6..128
+  config.password_length = 8..128
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly


### PR DESCRIPTION
## Summary
- Adds server-side `PasswordComplexityValidator` requiring uppercase, lowercase, digit, and special character
- Adds `password-complexity` Stimulus controller with live checklist UI (check/circle icons per rule)
- Bumps minimum password length from 6 to 8 in Devise config
- Wired up across all password input views (sign up, edit profile, password reset, forced change, onboarding)

## Test plan
- [ ] Sign up with a weak password (e.g. "password") and verify server-side errors
- [ ] Sign up and verify the live checklist updates as you type
- [ ] Verify checklist appears on password reset, profile edit, and onboarding forms
- [ ] Verify existing users with short passwords can still log in but must meet complexity on password change