### PR TITLE
Add request timeouts to Artifact Hub HTTP calls

### DIFF
--- a/app/actions/add_ons/fetch_chart_details_from_artifact_hub.rb
+++ b/app/actions/add_ons/fetch_chart_details_from_artifact_hub.rb
@@ -14,7 +14,7 @@ class AddOns::FetchChartDetailsFromArtifactHub
       "https://artifacthub.io/api/v1/packages/#{context.artifact_hub_package_id}"
     end
 
-    response = HTTParty.get(url)
+    response = HTTParty.get(url, timeout: 10)
     if response.success?
       context.response = response.parsed_response
     else

--- a/app/actions/add_ons/helm_chart_search.rb
+++ b/app/actions/add_ons/helm_chart_search.rb
@@ -4,7 +4,7 @@ class AddOns::HelmChartSearch
   promises :response
 
   executed do |context|
-    response = HTTParty.get("https://artifacthub.io/api/v1/packages/search?ts_query_web=#{context.query}")
+    response = HTTParty.get("https://artifacthub.io/api/v1/packages/search?ts_query_web=#{context.query}", timeout: 10)
     context.response = response.parsed_response
   end
 end

--- a/app/actions/add_ons/helm_chart_values_schema.rb
+++ b/app/actions/add_ons/helm_chart_values_schema.rb
@@ -5,7 +5,8 @@ class AddOns::HelmChartValuesSchema
 
   executed do |context|
     response = HTTParty.get(
-      "https://artifacthub.io/api/v1/packages/#{context.package_id}/#{context.version}/values-schema"
+      "https://artifacthub.io/api/v1/packages/#{context.package_id}/#{context.version}/values-schema",
+      timeout: 10
     )
 
     if response.success?


### PR DESCRIPTION
The Artifact Hub lookups run straight from the request path - /add_ons/search hits HelmChartSearch, and the add-on metadata endpoint hits FetchChartDetailsFromArtifactHub and HelmChartValuesSchema - but those HTTParty.get calls don't set a timeout, and HTTParty waits forever by default. If artifacthub.io is slow or hanging, each of those requests pins a Puma thread until the upstream eventually responds, and enough of them will exhaust the pool. I added timeout: 10 to the three calls, matching what FetchChartDetailsFromRepositoryUrl already does. Small change, just makes the external calls give up instead of blocking indefinitely.