### PR TITLE
Add Canine logo and project favicon to healthcheck emails

### DIFF
--- a/app/mailers/service_health_mailer.rb
+++ b/app/mailers/service_health_mailer.rb
@@ -4,6 +4,8 @@ class ServiceHealthMailer < ApplicationMailer
     @service = service
     @project = service.project
     @user = user
+    @favicon_url = project_favicon_url
+    attachments.inline["logo.webp"] = File.read(Rails.root.join("public/images/dark.webp"))
     mail(to: user.email, subject: "[Canine] #{@project.name}/#{@service.name} is down")
   end
 
@@ -11,6 +13,17 @@ class ServiceHealthMailer < ApplicationMailer
     @service = service
     @project = service.project
     @user = user
+    @favicon_url = project_favicon_url
+    attachments.inline["logo.webp"] = File.read(Rails.root.join("public/images/dark.webp"))
     mail(to: user.email, subject: "[Canine] #{@project.name}/#{@service.name} is back up")
+  end
+
+  private
+
+  def project_favicon_url
+    domain = @service.domains.first&.domain_name
+    return nil if domain.blank?
+
+    FaviconService.new(domain).fetch_url(size: 32, provider: :google)
   end
 end

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -13,7 +13,11 @@
             <!-- Logo -->
             <tr>
               <td style="padding: 0 0 32px 0;">
-                <span style="font-size: 20px; font-weight: 700; color: #1e2328; letter-spacing: -0.5px;">Canine</span>
+                <% if attachments["logo.webp"].present? %>
+                  <img src="<%= attachments["logo.webp"].url %>" alt="Canine" height="48" style="height: 48px; width: auto; display: block;">
+                <% else %>
+                  <span style="font-size: 20px; font-weight: 700; color: #1e2328; letter-spacing: -0.5px;">Canine</span>
+                <% end %>
               </td>
             </tr>
             <!-- Content card -->

--- a/app/views/service_health_mailer/service_down.html.erb
+++ b/app/views/service_health_mailer/service_down.html.erb
@@ -1,4 +1,4 @@
-<h1 style="margin: 0 0 24px 0; font-size: 22px; font-weight: 600; color: #1e2328;"><code style="background-color: #f0f2f5; padding: 2px 6px; border-radius: 3px; font-size: 20px;"><%= @project.name %></code> / <code style="background-color: #f0f2f5; padding: 2px 6px; border-radius: 3px; font-size: 20px;"><%= @service.name %></code> is down</h1>
+<h1 style="margin: 0 0 24px 0; font-size: 22px; font-weight: 600; color: #1e2328;"><% if @favicon_url.present? %><img src="<%= @favicon_url %>" alt="" width="20" height="20" style="width: 20px; height: 20px; vertical-align: text-bottom; margin-right: 4px; border-radius: 3px;"><% end %><code style="background-color: #f0f2f5; padding: 2px 6px; border-radius: 3px; font-size: 20px;"><%= @project.name %></code> / <code style="background-color: #f0f2f5; padding: 2px 6px; border-radius: 3px; font-size: 20px;"><%= @service.name %></code> is down</h1>
 
 <table cellpadding="0" cellspacing="0" style="margin-bottom: 28px; font-size: 14px; line-height: 1.6;">
   <tr>

--- a/app/views/service_health_mailer/service_restored.html.erb
+++ b/app/views/service_health_mailer/service_restored.html.erb
@@ -1,4 +1,4 @@
-<h1 style="margin: 0 0 24px 0; font-size: 22px; font-weight: 600; color: #1e2328;"><code style="background-color: #f0f2f5; padding: 2px 6px; border-radius: 3px; font-size: 20px;"><%= @project.name %></code> / <code style="background-color: #f0f2f5; padding: 2px 6px; border-radius: 3px; font-size: 20px;"><%= @service.name %></code> is back up</h1>
+<h1 style="margin: 0 0 24px 0; font-size: 22px; font-weight: 600; color: #1e2328;"><% if @favicon_url.present? %><img src="<%= @favicon_url %>" alt="" width="20" height="20" style="width: 20px; height: 20px; vertical-align: text-bottom; margin-right: 4px; border-radius: 3px;"><% end %><code style="background-color: #f0f2f5; padding: 2px 6px; border-radius: 3px; font-size: 20px;"><%= @project.name %></code> / <code style="background-color: #f0f2f5; padding: 2px 6px; border-radius: 3px; font-size: 20px;"><%= @service.name %></code> is back up</h1>
 
 <table cellpadding="0" cellspacing="0" style="margin-bottom: 28px; font-size: 14px; line-height: 1.6;">
   <tr>


### PR DESCRIPTION
## Summary
- Add inline Canine logo (dark variant) to the mailer layout header, replacing the plain text "Canine"
- Show project favicon (via Google favicon service) next to the project name in service down/restored emails
- Mailer layout gracefully falls back to text when no logo attachment is present

## Test plan
- [x] Verified locally by sending test healthcheck email for project 135