### PR TITLE
Add workbench API endpoint for CLI sync

### DIFF
--- a/app/controllers/api/v1/projects/workbenches_controller.rb
+++ b/app/controllers/api/v1/projects/workbenches_controller.rb
@@ -1,0 +1,47 @@
+module Api
+  module V1
+    module Projects
+      class WorkbenchesController < BaseController
+        before_action :set_project
+
+        def show
+          unless @project.development_environment?
+            render json: { error: "Project is not a development environment" }, status: :unprocessable_entity
+            return
+          end
+
+          client = K8::Client.new(active_connection)
+          pods = client.get_pods(namespace: @project.namespace).select { |pod| pod.status.phase == "Running" }
+          @pod = pods.first
+
+          if @pod.nil?
+            render json: { error: "No running workbench pod found" }, status: :not_found
+            return
+          end
+
+          config = @project.child_development_environment&.parent_project&.development_environment_configuration
+          @workspace_mount_path = config&.workspace_mount_path || "/workspace"
+
+          render json: {
+            pod_name: @pod.metadata.name,
+            namespace: @project.namespace,
+            container: @project.name,
+            workspace_mount_path: @workspace_mount_path,
+            cluster_name: @project.cluster.name
+          }
+        end
+
+        private
+
+        def active_connection
+          @active_connection ||= K8::Connection.new(@project, current_user)
+        end
+
+        def set_project
+          projects = ::Projects::VisibleToUser.execute(account_user: current_account_user).projects
+          @project = projects.find_by_name!(params[:project_id])
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
           post :restart
         end
         resources :processes, only: %i[index show create destroy], module: :projects
+        resource :workbench, only: %i[show], module: :projects
       end
       resources :builds, only: %i[index show] do
         member do

--- a/spec/integration/api/models/workbench.rb
+++ b/spec/integration/api/models/workbench.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+SwaggerSchemas::WORKBENCH = {
+  type: :object,
+  required: %w[pod_name namespace container workspace_mount_path cluster_name],
+  properties: {
+    pod_name: {
+      type: :string,
+      example: 'workbench-pod-abc123'
+    },
+    namespace: {
+      type: :string,
+      example: 'my-project'
+    },
+    container: {
+      type: :string,
+      example: 'my-project'
+    },
+    workspace_mount_path: {
+      type: :string,
+      example: '/workspace'
+    },
+    cluster_name: {
+      type: :string,
+      example: 'production'
+    }
+  }
+}.freeze

--- a/spec/integration/api/v1/workbenches_spec.rb
+++ b/spec/integration/api/v1/workbenches_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'swagger_helper'
+
+RSpec.describe Api::V1::Projects::WorkbenchesController, :swagger, type: :request do
+  include ApplicationHelper
+  let(:api_token) { create :api_token, user: }
+  let(:'X-API-Key') { api_token.access_token }
+  let(:account) { create :account }
+  let(:user) { create :user }
+  let!(:account_user) { create :account_user, account:, user: }
+  let!(:cluster) { create :cluster, account: }
+  let(:project) { create :project, :container_registry, cluster:, account: }
+
+  let(:mock_pod) do
+    OpenStruct.new(
+      metadata: OpenStruct.new(
+        name: 'workbench-pod-abc123',
+        namespace: project.namespace,
+        creationTimestamp: '2021-01-01T00:00:00Z',
+        labels: { app: project.name }
+      ),
+      status: OpenStruct.new(phase: 'Running')
+    )
+  end
+
+  before do
+    allow_any_instance_of(K8::Client).to receive(:get_pods).and_return([ mock_pod ])
+
+    parent_project = create(:project, :container_registry, cluster:, account:)
+    create(:development_environment_configuration, project: parent_project, cluster:, workspace_mount_path: '/workspace')
+    provider = create(:provider, :github, user:)
+    create(:development_environment, parent_project: parent_project, child_project: project, git_provider: provider, created_by: user)
+  end
+
+  path '/api/v1/projects/{project_id}/workbench' do
+    let(:project_id) { project.name }
+
+    get('Show Workbench') do
+      tags 'Workbench'
+      operationId 'showWorkbench'
+      produces 'application/json'
+      parameter name: 'X-API-Key', in: :header, type: :string, description: 'API Key'
+      parameter name: :project_id, in: :path, type: :string, description: 'Project name'
+
+      response(200, 'successful') do
+        schema '$ref' => '#/components/schemas/workbench'
+        run_test!
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add `GET /api/v1/projects/:project_id/workbench` endpoint returning pod name, namespace, container, workspace mount path, and cluster name for a running workbench pod
- Used by the Canine CLI `workbench sync` and `workbench connect` commands to sync files and connect to dev environments
- Includes swagger test and schema model

## CLI side (separate repo: canine-cli)
The corresponding CLI changes add:
- `canine workbench sync --project <name> [--watch] [--direction up|down]` — sync files via `kubectl cp`/`exec` with tar
- `canine workbench connect --project <name>` — interactive shell into workbench pod

## Test plan
- [x] Swagger test passes (`spec/integration/api/v1/workbenches_spec.rb`)
- [ ] Test endpoint with a real workbench project