### PR TITLE
Add feedback for test notification button

### DIFF
--- a/app/actions/notifiers/send_test.rb
+++ b/app/actions/notifiers/send_test.rb
@@ -5,15 +5,19 @@ class Notifiers::SendTest
   executed do |context|
     test_event = TestNotifier.new(project: context.project, notifier: context.notifier)
 
-    if context.notifier.email?
-      NotifierMailer.test_notification(context.user, test_event).deliver_now
-    else
-      payload = test_event.build_payload(context.notifier.provider_type)
-      HTTParty.post(
-        context.notifier.webhook_url,
-        headers: { "Content-Type" => "application/json" },
-        body: payload.to_json
-      )
+    begin
+      if context.notifier.email?
+        NotifierMailer.test_notification(context.user, test_event).deliver_now
+      else
+        payload = test_event.build_payload(context.notifier.provider_type)
+        HTTParty.post(
+          context.notifier.webhook_url,
+          headers: { "Content-Type" => "application/json" },
+          body: payload.to_json
+        )
+      end
+    rescue StandardError => e
+      context.fail_and_return!("#{e.message}")
     end
   end
 end

--- a/app/controllers/projects/notifiers_controller.rb
+++ b/app/controllers/projects/notifiers_controller.rb
@@ -35,8 +35,12 @@ class Projects::NotifiersController < Projects::BaseController
   end
 
   def test
-    Notifiers::SendTest.execute(notifier: @notifier, project: @project, user: current_user)
-    render partial: "index", locals: { project: @project }
+    result = Notifiers::SendTest.execute(notifier: @notifier, project: @project, user: current_user)
+    if result.success?
+      render partial: "index", locals: { project: @project, notice: "Test notification sent successfully." }
+    else
+      render partial: "index", locals: { project: @project, alert: "Failed to send test notification: #{result.message}" }
+    end
   end
 
   private

--- a/app/views/projects/notifiers/_index.html.erb
+++ b/app/views/projects/notifiers/_index.html.erb
@@ -1,5 +1,10 @@
 <%= turbo_frame_tag "notifiers" do %>
 <div class="space-y-4">
+  <% if local_assigns[:notice] %>
+    <div class="alert alert-success" role="alert"><%= notice %></div>
+  <% elsif local_assigns[:alert] %>
+    <div class="alert alert-error" role="alert"><%= alert %></div>
+  <% end %>
   <div class="text-base-content/50">
     Set up webhook notifications to receive real-time alerts about builds, deployments, and service health. Supports Slack, Discord, Microsoft Teams, Google Chat, and email.
   </div>


### PR DESCRIPTION
## Summary
- Show inline success/error alert in the notifiers turbo frame after clicking "Send Test Notification"
- Add error handling in `Notifiers::SendTest` action so network/delivery failures are caught and reported
- Pass feedback as locals to the partial instead of using flash (works within turbo frame)

## Test plan
- [ ] Click "Send Test Notification" on a notifier with a valid webhook — verify success alert appears
- [ ] Click "Send Test Notification" on a notifier with an invalid webhook URL — verify error alert appears
- [ ] Test with an email notifier — verify success alert appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)