### PR TITLE
Add Stripe billing for per-cluster pricing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -117,3 +117,5 @@ gem "doorkeeper", "~> 5.8"
 
 gem "rotp", "~> 6.3"
 gem "rqrcode", "~> 2.2"
+
+gem "stripe", "~> 19.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -669,6 +669,9 @@ GEM
       sprockets (>= 3.0.0)
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
+    stripe (19.5.0)
+      bigdecimal
+      logger
     swd (2.0.3)
       activesupport (>= 3)
       attr_required (>= 0.0.5)
@@ -815,6 +818,7 @@ DEPENDENCIES
   sitemap_generator (~> 6.1)
   sprockets-rails
   stimulus-rails
+  stripe (~> 19.5)
   sys-proctable (~> 1.3)
   tailwindcss-rails (~> 2.7)
   turbo-rails

--- a/app/controllers/accounts/account_users_controller.rb
+++ b/app/controllers/accounts/account_users_controller.rb
@@ -1,7 +1,12 @@
 class Accounts::AccountUsersController < ApplicationController
   include SettingsHelper
 
+  include BillableEnforcement
+
   def create
+    enforce_plan_limit!(:team_members)
+    return if performed?
+
     email = user_params[:email].downcase
     existing_member = current_account.users.find_by(email: email)
 
@@ -59,6 +64,9 @@ class Accounts::AccountUsersController < ApplicationController
 
   def index
     @pagy, @account_users = pagy(current_account.account_users)
+    if Rails.configuration.cloud_mode
+      @plan_usage = current_account.plan_usage(:team_members)
+    end
   end
 
 

--- a/app/controllers/accounts/account_users_controller.rb
+++ b/app/controllers/accounts/account_users_controller.rb
@@ -1,5 +1,6 @@
 class Accounts::AccountUsersController < ApplicationController
   include SettingsHelper
+
   def create
     email = user_params[:email].downcase
     existing_member = current_account.users.find_by(email: email)

--- a/app/controllers/accounts/billing_controller.rb
+++ b/app/controllers/accounts/billing_controller.rb
@@ -1,0 +1,46 @@
+class Accounts::BillingController < ApplicationController
+  def show
+  end
+
+  def checkout
+    ensure_stripe_customer!
+
+    session = Stripe::Checkout::Session.create(
+      customer: current_account.stripe_customer_id,
+      mode: "subscription",
+      line_items: [ {
+        price: ENV["STRIPE_CLUSTER_PRICE_ID"],
+        quantity: [ current_account.billable_clusters_count, 1 ].max
+      } ],
+      success_url: billing_url + "?session_id={CHECKOUT_SESSION_ID}",
+      cancel_url: billing_url,
+      metadata: { account_id: current_account.id }
+    )
+
+    redirect_to session.url, allow_other_host: true, status: :see_other
+  end
+
+  def portal
+    ensure_stripe_customer!
+
+    session = Stripe::BillingPortal::Session.create(
+      customer: current_account.stripe_customer_id,
+      return_url: billing_url
+    )
+
+    redirect_to session.url, allow_other_host: true, status: :see_other
+  end
+
+  private
+
+  def ensure_stripe_customer!
+    return if current_account.stripe_customer_id.present?
+
+    customer = Stripe::Customer.create(
+      email: current_user.email,
+      name: current_account.name,
+      metadata: { account_id: current_account.id, account_name: current_account.name }
+    )
+    current_account.update!(stripe_customer_id: customer.id)
+  end
+end

--- a/app/controllers/accounts/billing_controller.rb
+++ b/app/controllers/accounts/billing_controller.rb
@@ -1,4 +1,6 @@
 class Accounts::BillingController < ApplicationController
+  before_action { redirect_to root_path unless Rails.configuration.cloud_mode }
+
   def show
   end
 

--- a/app/controllers/clusters_controller.rb
+++ b/app/controllers/clusters_controller.rb
@@ -23,6 +23,9 @@ class ClustersController < ApplicationController
 
   def new
     @cluster = Cluster.new
+    if Rails.configuration.cloud_mode
+      @plan_usage = current_account.plan_usage(:clusters)
+    end
   end
 
   def edit

--- a/app/controllers/clusters_controller.rb
+++ b/app/controllers/clusters_controller.rb
@@ -1,4 +1,6 @@
 class ClustersController < ApplicationController
+  include BillableEnforcement
+
   before_action :set_cluster, only: [
     :show, :edit, :update, :destroy,
     :test_connection, :download_kubeconfig, :logs, :download_yaml,
@@ -83,6 +85,9 @@ class ClustersController < ApplicationController
   end
 
   def create
+    enforce_plan_limit!(:clusters)
+    return if performed?
+
     result = Clusters::Create.call(params, current_account_user)
     @cluster = result.cluster
 

--- a/app/controllers/clusters_controller.rb
+++ b/app/controllers/clusters_controller.rb
@@ -11,6 +11,7 @@ class ClustersController < ApplicationController
     sortable_column = params[:sort] || "created_at"
     clusters = Clusters::List.call(account_user: current_account_user, params: params).clusters
     @pagy, @clusters = pagy(clusters.order(sortable_column => "asc"))
+    @plan_usage = current_account.plan_usage(:clusters) if Rails.configuration.cloud_mode
 
     respond_to do |format|
       format.html

--- a/app/controllers/concerns/billable_enforcement.rb
+++ b/app/controllers/concerns/billable_enforcement.rb
@@ -4,6 +4,7 @@ module BillableEnforcement
   private
 
   def enforce_plan_limit!(resource)
+    return unless Rails.configuration.cloud_mode
     return if current_account.within_plan_limit?(resource)
 
     redirect_to billing_path,

--- a/app/controllers/concerns/billable_enforcement.rb
+++ b/app/controllers/concerns/billable_enforcement.rb
@@ -1,0 +1,12 @@
+module BillableEnforcement
+  extend ActiveSupport::Concern
+
+  private
+
+  def enforce_plan_limit!(resource)
+    return if current_account.within_plan_limit?(resource)
+
+    redirect_to billing_path,
+      alert: "You've reached the #{resource} limit for your plan. Please upgrade to add more."
+  end
+end

--- a/app/controllers/webhooks/stripe_controller.rb
+++ b/app/controllers/webhooks/stripe_controller.rb
@@ -5,6 +5,8 @@ module Webhooks
     skip_before_action :check_password_change_required
 
     def create
+      return head :not_found unless Rails.configuration.cloud_mode
+
       payload = request.body.read
       sig_header = request.env["HTTP_STRIPE_SIGNATURE"]
 

--- a/app/controllers/webhooks/stripe_controller.rb
+++ b/app/controllers/webhooks/stripe_controller.rb
@@ -1,0 +1,68 @@
+module Webhooks
+  class StripeController < ApplicationController
+    skip_before_action :verify_authenticity_token
+    skip_before_action :authenticate_user!
+    skip_before_action :check_password_change_required
+
+    def create
+      payload = request.body.read
+      sig_header = request.env["HTTP_STRIPE_SIGNATURE"]
+
+      event = Stripe::Webhook.construct_event(
+        payload, sig_header, ENV["STRIPE_WEBHOOK_SECRET"]
+      )
+
+      handle_event(event)
+      head :ok
+    rescue Stripe::SignatureVerificationError
+      head :bad_request
+    rescue JSON::ParserError
+      head :bad_request
+    end
+
+    private
+
+    def handle_event(event)
+      case event.type
+      when "checkout.session.completed"
+        handle_checkout_completed(event.data.object)
+      when "customer.subscription.updated"
+        handle_subscription_updated(event.data.object)
+      when "customer.subscription.deleted"
+        handle_subscription_deleted(event.data.object)
+      end
+    end
+
+    def handle_checkout_completed(session)
+      account = Account.find_by(id: session.metadata["account_id"])
+      return unless account
+
+      subscription = Stripe::Subscription.retrieve(session.subscription)
+
+      account.update!(
+        stripe_subscription_id: subscription.id,
+        subscription_status: subscription.status,
+        plan: :pro,
+        trial_ends_at: subscription.trial_end ? Time.at(subscription.trial_end) : nil
+      )
+    end
+
+    def handle_subscription_updated(subscription)
+      account = Account.find_by(stripe_subscription_id: subscription.id)
+      return unless account
+
+      account.update!(subscription_status: subscription.status)
+    end
+
+    def handle_subscription_deleted(subscription)
+      account = Account.find_by(stripe_subscription_id: subscription.id)
+      return unless account
+
+      account.update!(
+        plan: :free,
+        subscription_status: "canceled",
+        stripe_subscription_id: nil
+      )
+    end
+  end
+end

--- a/app/jobs/stripe_sync_usage_job.rb
+++ b/app/jobs/stripe_sync_usage_job.rb
@@ -1,0 +1,20 @@
+class StripeSyncUsageJob < ApplicationJob
+  queue_as :default
+
+  def perform(account)
+    return unless account.stripe_subscription_id.present?
+    return unless account.active_subscription?
+
+    subscription = Stripe::Subscription.retrieve(account.stripe_subscription_id)
+    item = subscription.items.data.first
+
+    new_quantity = account.billable_clusters_count
+
+    if new_quantity > 0
+      Stripe::SubscriptionItem.update(item.id, quantity: new_quantity)
+    elsif new_quantity == 0
+      # Back to free tier usage, cancel the subscription
+      Stripe::Subscription.cancel(subscription.id)
+    end
+  end
+end

--- a/app/jobs/stripe_sync_usage_job.rb
+++ b/app/jobs/stripe_sync_usage_job.rb
@@ -2,6 +2,7 @@ class StripeSyncUsageJob < ApplicationJob
   queue_as :default
 
   def perform(account)
+    return unless Rails.configuration.cloud_mode
     return unless account.stripe_subscription_id.present?
     return unless account.active_subscription?
 

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -2,24 +2,33 @@
 #
 # Table name: accounts
 #
-#  id         :bigint           not null, primary key
-#  allow_mcp  :boolean          default(TRUE), not null
-#  name       :string           not null
-#  slug       :string           not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  owner_id   :bigint
+#  id                     :bigint           not null, primary key
+#  allow_mcp              :boolean          default(TRUE), not null
+#  name                   :string           not null
+#  plan                   :integer          default("free"), not null
+#  slug                   :string           not null
+#  subscription_status    :string
+#  trial_ends_at          :datetime
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  owner_id               :bigint
+#  stripe_customer_id     :string
+#  stripe_subscription_id :string
 #
 # Indexes
 #
-#  index_accounts_on_owner_id  (owner_id)
-#  index_accounts_on_slug      (slug) UNIQUE
+#  index_accounts_on_owner_id                (owner_id)
+#  index_accounts_on_slug                    (slug) UNIQUE
+#  index_accounts_on_stripe_customer_id      (stripe_customer_id) UNIQUE
+#  index_accounts_on_stripe_subscription_id  (stripe_subscription_id) UNIQUE
 #
 # Foreign Keys
 #
 #  fk_rails_...  (owner_id => users.id)
 #
 class Account < ApplicationRecord
+  include Billable
+
   extend FriendlyId
   friendly_id :name, use: :slugged
 

--- a/app/models/cluster.rb
+++ b/app/models/cluster.rb
@@ -41,6 +41,9 @@ class Cluster < ApplicationRecord
   has_many :users, through: :account
   has_one :build_cloud, dependent: :destroy
 
+  after_create_commit :sync_billing
+  after_destroy_commit :sync_billing
+
   validates :name, presence: true,
                    format: { with: /\A[a-z0-9-]+\z/, message: "must be lowercase, numbers, and hyphens only" },
                    uniqueness: { scope: :account_id }
@@ -76,6 +79,10 @@ class Cluster < ApplicationRecord
   end
 
   private
+
+  def sync_billing
+    StripeSyncUsageJob.perform_later(account) if account.pro?
+  end
 
   def create_build_cloud_record!(attributes)
     build_cloud = BuildCloud.new(attributes.merge(cluster: self))

--- a/app/models/cluster.rb
+++ b/app/models/cluster.rb
@@ -81,6 +81,7 @@ class Cluster < ApplicationRecord
   private
 
   def sync_billing
+    return unless Rails.configuration.cloud_mode
     StripeSyncUsageJob.perform_later(account) if account.pro?
   end
 

--- a/app/models/concerns/billable.rb
+++ b/app/models/concerns/billable.rb
@@ -1,0 +1,43 @@
+module Billable
+  extend ActiveSupport::Concern
+
+  FREE_CLUSTER_LIMIT = 1
+  FREE_TEAM_MEMBERS_LIMIT = 5
+
+  PLAN_COUNTERS = {
+    clusters: ->(account) { account.clusters.count },
+    team_members: ->(account) { account.users.count }
+  }.freeze
+
+  included do
+    enum :plan, { free: 0, pro: 1 }
+  end
+
+  def plan_limit(resource)
+    case resource
+    when :clusters
+      pro? ? Float::INFINITY : FREE_CLUSTER_LIMIT
+    when :team_members
+      pro? ? Float::INFINITY : FREE_TEAM_MEMBERS_LIMIT
+    end
+  end
+
+  def within_plan_limit?(resource)
+    counter = PLAN_COUNTERS[resource]
+    return true unless counter
+
+    counter.call(self) < plan_limit(resource)
+  end
+
+  def billable_clusters_count
+    [ clusters.count - FREE_CLUSTER_LIMIT, 0 ].max
+  end
+
+  def active_subscription?
+    subscription_status.in?(%w[active trialing])
+  end
+
+  def needs_subscription?
+    clusters.count > FREE_CLUSTER_LIMIT && !active_subscription?
+  end
+end

--- a/app/models/concerns/billable.rb
+++ b/app/models/concerns/billable.rb
@@ -22,6 +22,13 @@ module Billable
     end
   end
 
+  def plan_usage(resource)
+    counter = PLAN_COUNTERS[resource]
+    return nil unless counter
+
+    { current: counter.call(self), limit: plan_limit(resource) }
+  end
+
   def within_plan_limit?(resource)
     counter = PLAN_COUNTERS[resource]
     return true unless counter

--- a/app/views/accounts/account_users/index.html.erb
+++ b/app/views/accounts/account_users/index.html.erb
@@ -27,12 +27,15 @@
       <% end %>
     </div>
 
+    <%= render "shared/plan_limit_notice", resource: "team member", plan_usage: @plan_usage %>
+
+    <% plan_limit_reached = @plan_usage && @plan_usage[:current] >= @plan_usage[:limit] %>
     <div class="mt-5">
       <div aria-label="Card" class="card card-bordered bg-base-100">
         <div class="card-body">
           <div class="text-right px-5 pt-5">
               <!--  Start: User Action -->
-               <button class="btn btn-primary btn-sm" onclick="team_member_modal.showModal()">
+               <button class="btn btn-primary btn-sm" onclick="team_member_modal.showModal()" <%= 'disabled' if plan_limit_reached %>>
                   <iconify-icon icon="lucide:plus" height="16"></iconify-icon>
                   <span class="hidden sm:inline">Add Team Member</span>
                 </button>

--- a/app/views/accounts/billing/show.html.erb
+++ b/app/views/accounts/billing/show.html.erb
@@ -1,0 +1,71 @@
+<%= settings_layout do %>
+  <div class="space-y-8">
+    <div>
+      <h2 class="text-2xl font-bold">Billing</h2>
+      <p class="text-sm text-gray-500 mt-1">Manage your subscription and billing details.</p>
+      <hr class="mt-3 mb-6 border-t border-base-300" />
+    </div>
+
+    <div class="rounded-lg bg-base-200 p-6">
+      <div class="flex items-center justify-between">
+        <div>
+          <p class="text-sm text-gray-500">Current Plan</p>
+          <p class="text-2xl font-bold mt-1 capitalize"><%= current_account.plan %></p>
+          <% if current_account.subscription_status == "trialing" && current_account.trial_ends_at&.future? %>
+            <p class="text-sm text-warning mt-1">Trial ends <%= time_ago(current_account.trial_ends_at) %></p>
+          <% elsif current_account.subscription_status.present? %>
+            <p class="text-sm text-gray-500 mt-1 capitalize">Status: <%= current_account.subscription_status %></p>
+          <% end %>
+        </div>
+        <div class="text-right">
+          <p class="text-sm text-gray-500">Clusters</p>
+          <p class="text-sm mt-1">
+            <span class="font-semibold"><%= current_account.clusters.count %></span> total
+          </p>
+          <% if current_account.billable_clusters_count > 0 %>
+            <p class="text-sm text-gray-400">
+              1 free + <%= current_account.billable_clusters_count %> paid ($<%= current_account.billable_clusters_count * 20 %>/mo)
+            </p>
+          <% else %>
+            <p class="text-sm text-gray-400">1 free cluster included</p>
+          <% end %>
+        </div>
+      </div>
+    </div>
+
+    <% if current_account.stripe_customer_id.present? && current_account.pro? %>
+      <div>
+        <%= button_to "Manage Billing", portal_billing_path, method: :post, class: "btn btn-primary", data: { turbo: false, disable_with: "Redirecting..." } %>
+        <p class="text-xs text-gray-500 mt-2">Update payment method, view invoices, or cancel your subscription.</p>
+      </div>
+    <% end %>
+
+    <% if current_account.free? %>
+      <div class="rounded-lg border border-base-300 p-6 max-w-lg">
+        <h3 class="text-lg font-semibold mb-2">Upgrade to Pro</h3>
+        <p class="text-sm text-gray-400 mb-4">
+          Add unlimited clusters at $20/month each. Your first cluster is always free.
+        </p>
+        <ul class="space-y-2 text-sm text-gray-400 mb-6">
+          <li class="flex items-center gap-2">
+            <iconify-icon icon="lucide:check" class="text-primary"></iconify-icon>
+            Unlimited clusters ($20/mo per additional)
+          </li>
+          <li class="flex items-center gap-2">
+            <iconify-icon icon="lucide:check" class="text-primary"></iconify-icon>
+            Unlimited team members
+          </li>
+          <li class="flex items-center gap-2">
+            <iconify-icon icon="lucide:check" class="text-primary"></iconify-icon>
+            Priority support
+          </li>
+          <li class="flex items-center gap-2">
+            <iconify-icon icon="lucide:check" class="text-primary"></iconify-icon>
+            SSO / SAML authentication
+          </li>
+        </ul>
+        <%= button_to "Upgrade to Pro", checkout_billing_path, method: :post, class: "btn btn-primary w-full", data: { turbo: false, disable_with: "Redirecting..." } %>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/clusters/index.html.erb
+++ b/app/views/clusters/index.html.erb
@@ -6,6 +6,8 @@
     <h3 class="text-lg font-medium">Clusters</h3>
   </div>
 
+  <%= render "shared/plan_limit_notice", resource: "cluster", plan_usage: @plan_usage %>
+
   <div class="mt-5">
     <div aria-label="Card" class="card card-bordered bg-base-100">
       <div class="card-body">

--- a/app/views/clusters/new.html.erb
+++ b/app/views/clusters/new.html.erb
@@ -9,7 +9,9 @@
     </h1>
   </div>
 
-  <div class="card card-bordered bg-base-100">
+  <%= render "shared/plan_limit_notice", resource: "cluster", plan_usage: @plan_usage %>
+
+  <div class="card card-bordered bg-base-100 <%= 'opacity-50 pointer-events-none select-none' if @plan_usage && @plan_usage[:current] >= @plan_usage[:limit] %>">
     <div class="card-body">
       <%= render "form", cluster: @cluster %>
     </div>

--- a/app/views/settings/_layout.html.erb
+++ b/app/views/settings/_layout.html.erb
@@ -62,6 +62,12 @@
               Authentication
             <% end %>
           </li>
+          <li class="<%= 'underline' if controller_name == 'billing' %>" style="text-underline-offset: 0.25rem;">
+            <%= link_to billing_path do %>
+              <iconify-icon icon="lucide:credit-card" ></iconify-icon>
+              Billing
+            <% end %>
+          </li>
           <li class="<%= 'underline' if controller_name == 'stack_managers' %>" style="text-underline-offset: 0.25rem;">
             <%= link_to stack_manager_path do %>
               <iconify-icon icon="lucide:layers" ></iconify-icon>

--- a/app/views/settings/_layout.html.erb
+++ b/app/views/settings/_layout.html.erb
@@ -62,12 +62,14 @@
               Authentication
             <% end %>
           </li>
+          <% if Rails.configuration.cloud_mode %>
           <li class="<%= 'underline' if controller_name == 'billing' %>" style="text-underline-offset: 0.25rem;">
             <%= link_to billing_path do %>
               <iconify-icon icon="lucide:credit-card" ></iconify-icon>
               Billing
             <% end %>
           </li>
+          <% end %>
           <li class="<%= 'underline' if controller_name == 'stack_managers' %>" style="text-underline-offset: 0.25rem;">
             <%= link_to stack_manager_path do %>
               <iconify-icon icon="lucide:layers" ></iconify-icon>

--- a/app/views/shared/_plan_limit_notice.html.erb
+++ b/app/views/shared/_plan_limit_notice.html.erb
@@ -1,0 +1,20 @@
+<% if plan_usage.present? %>
+  <% current = plan_usage[:current] %>
+  <% limit = plan_usage[:limit] %>
+  <% reached = current >= limit %>
+  <% percentage = limit.infinite? ? 0 : (current.to_f / limit * 100).clamp(0, 100) %>
+
+  <div class="rounded-lg border p-4 my-4 <%= reached ? 'border-warning bg-warning/10' : 'border-info bg-info/10' %>">
+    <div class="flex justify-between items-center mb-2">
+      <span class="font-semibold capitalize"><%= resource %> limit</span>
+      <span class="font-mono text-sm"><%= current %>/<%= limit.infinite? ? '∞' : limit %></span>
+    </div>
+    <progress class="progress <%= reached ? 'progress-warning' : 'progress-primary' %> w-full" value="<%= percentage %>" max="100"></progress>
+    <% if reached %>
+      <div class="flex justify-between items-center text-sm mt-2">
+        <span class="opacity-70">You've reached your plan limit.</span>
+        <%= link_to "Upgrade to Pro", billing_path, class: "underline font-semibold" %>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/shared/_plan_limit_notice.html.erb
+++ b/app/views/shared/_plan_limit_notice.html.erb
@@ -4,17 +4,17 @@
   <% reached = current >= limit %>
   <% percentage = limit.infinite? ? 0 : (current.to_f / limit * 100).clamp(0, 100) %>
 
-  <div class="rounded-lg border p-4 my-4 <%= reached ? 'border-warning bg-warning/10' : 'border-info bg-info/10' %>">
-    <div class="flex justify-between items-center mb-2">
-      <span class="font-semibold capitalize"><%= resource %> limit</span>
-      <span class="font-mono text-sm"><%= current %>/<%= limit.infinite? ? '∞' : limit %></span>
-    </div>
-    <progress class="progress <%= reached ? 'progress-warning' : 'progress-primary' %> w-full" value="<%= percentage %>" max="100"></progress>
-    <% if reached %>
+  <% if reached %>
+    <div class="rounded-lg border border-warning bg-warning/10 p-4 my-4">
+      <div class="flex justify-between items-center mb-2">
+        <span class="font-semibold capitalize"><%= resource %> limit</span>
+        <span class="font-mono text-sm"><%= current %>/<%= limit.infinite? ? '∞' : limit %></span>
+      </div>
+      <progress class="progress progress-warning w-full" value="<%= percentage %>" max="100"></progress>
       <div class="flex justify-between items-center text-sm mt-2">
         <span class="opacity-70">You've reached your plan limit.</span>
         <%= link_to "Upgrade to Pro", billing_path, class: "underline font-semibold" %>
       </div>
-    <% end %>
-  </div>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/static/index.html.erb
+++ b/app/views/static/index.html.erb
@@ -64,6 +64,9 @@
       <!-- Pricing section -->
       <%= render "static/landing_page/pricing" %>
 
+      <!-- Plans section -->
+      <%= render "static/landing_page/plans" %>
+
       <!-- Feature section -->
       <%= render "static/landing_page/features_1" %>
 

--- a/app/views/static/landing_page/_plans.html.erb
+++ b/app/views/static/landing_page/_plans.html.erb
@@ -1,0 +1,76 @@
+<div id="plans" class="mx-auto mt-16 max-w-7xl px-6 sm:mt-24 lg:px-8">
+  <div class="mx-auto max-w-2xl sm:text-center" data-aos="fade-up">
+    <h2 class="text-base font-semibold leading-7 text-indigo-400"><a href="#plans" class="hover:underline underline-offset-4">Simple Pricing</a></h2>
+    <p class="mt-2 text-3xl font-bold tracking-tight text-white sm:text-4xl">One cluster free, forever</p>
+    <p class="mt-6 text-lg leading-8 text-gray-300">Your first cluster is always free. Need more? $20/month per additional cluster. No hidden fees, no per-seat charges.</p>
+  </div>
+
+  <div class="mx-auto mt-12 grid max-w-lg grid-cols-1 gap-8 lg:max-w-4xl lg:grid-cols-2" data-aos="fade-up" data-aos-delay="150">
+    <!-- Free tier -->
+    <div class="rounded-2xl bg-white/5 ring-1 ring-white/10 p-8">
+      <h3 class="text-lg font-semibold leading-8 text-white">Free</h3>
+      <p class="mt-4 text-sm leading-6 text-gray-300">Everything you need to deploy your first application.</p>
+      <p class="mt-6 flex items-baseline gap-x-1">
+        <span class="text-4xl font-bold tracking-tight text-white">$0</span>
+        <span class="text-sm font-semibold leading-6 text-gray-300">/month</span>
+      </p>
+      <%= link_to "Get started for free", new_user_registration_path, class: "mt-6 block rounded-md bg-indigo-500 px-3 py-2 text-center text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500" %>
+      <ul role="list" class="mt-8 space-y-3 text-sm leading-6 text-gray-300">
+        <li class="flex gap-x-3">
+          <iconify-icon icon="lucide:check" class="text-indigo-400 mt-0.5" height="18"></iconify-icon>
+          1 cluster included
+        </li>
+        <li class="flex gap-x-3">
+          <iconify-icon icon="lucide:check" class="text-indigo-400 mt-0.5" height="18"></iconify-icon>
+          Unlimited projects
+        </li>
+        <li class="flex gap-x-3">
+          <iconify-icon icon="lucide:check" class="text-indigo-400 mt-0.5" height="18"></iconify-icon>
+          Unlimited deployments
+        </li>
+        <li class="flex gap-x-3">
+          <iconify-icon icon="lucide:check" class="text-indigo-400 mt-0.5" height="18"></iconify-icon>
+          SSL certificates
+        </li>
+        <li class="flex gap-x-3">
+          <iconify-icon icon="lucide:check" class="text-indigo-400 mt-0.5" height="18"></iconify-icon>
+          GitHub & GitLab integration
+        </li>
+      </ul>
+    </div>
+
+    <!-- Pro tier -->
+    <div class="rounded-2xl bg-indigo-500/10 ring-2 ring-indigo-500 p-8">
+      <h3 class="text-lg font-semibold leading-8 text-indigo-400">Pro</h3>
+      <p class="mt-4 text-sm leading-6 text-gray-300">Scale to multiple clusters as your team grows.</p>
+      <p class="mt-6 flex items-baseline gap-x-1">
+        <span class="text-4xl font-bold tracking-tight text-white">$20</span>
+        <span class="text-sm font-semibold leading-6 text-gray-300">/cluster/month</span>
+      </p>
+      <p class="mt-1 text-xs text-gray-400">Per additional cluster beyond the first</p>
+      <%= link_to "Get started", new_user_registration_path, class: "mt-6 block rounded-md bg-indigo-500 px-3 py-2 text-center text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500" %>
+      <ul role="list" class="mt-8 space-y-3 text-sm leading-6 text-gray-300">
+        <li class="flex gap-x-3">
+          <iconify-icon icon="lucide:check" class="text-indigo-400 mt-0.5" height="18"></iconify-icon>
+          Everything in Free
+        </li>
+        <li class="flex gap-x-3">
+          <iconify-icon icon="lucide:check" class="text-indigo-400 mt-0.5" height="18"></iconify-icon>
+          Unlimited additional clusters ($20/mo each)
+        </li>
+        <li class="flex gap-x-3">
+          <iconify-icon icon="lucide:check" class="text-indigo-400 mt-0.5" height="18"></iconify-icon>
+          Unlimited team members
+        </li>
+        <li class="flex gap-x-3">
+          <iconify-icon icon="lucide:check" class="text-indigo-400 mt-0.5" height="18"></iconify-icon>
+          Priority support
+        </li>
+        <li class="flex gap-x-3">
+          <iconify-icon icon="lucide:check" class="text-indigo-400 mt-0.5" height="18"></iconify-icon>
+          SSO / SAML authentication
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>

--- a/config/initializers/stripe.rb
+++ b/config/initializers/stripe.rb
@@ -1,0 +1,2 @@
+Stripe.api_key = ENV["STRIPE_SECRET_KEY"]
+Stripe.api_version = "2025-03-31.basil"

--- a/config/initializers/stripe.rb
+++ b/config/initializers/stripe.rb
@@ -1,2 +1,4 @@
-Stripe.api_key = ENV["STRIPE_SECRET_KEY"]
-Stripe.api_version = "2025-03-31.basil"
+if Rails.configuration.cloud_mode
+  Stripe.api_key = ENV["STRIPE_SECRET_KEY"]
+  Stripe.api_version = "2025-03-31.basil"
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,6 +76,10 @@ Rails.application.routes.draw do
   resources :accounts, only: [ :create, :update, :edit ] do
     collection do
       resources :account_users, only: %i[create index update destroy], module: :accounts
+      resource :billing, only: %i[show], module: :accounts, controller: :billing do
+        post :checkout
+        post :portal
+      end
       resource :sso_provider, only: %i[show new create edit update destroy], module: :accounts do
         post :test_connection
       end
@@ -103,6 +107,9 @@ Rails.application.routes.draw do
     resources :github, controller: :github, only: [ :create ]
     resources :gitlab, controller: :gitlab, only: [ :create ]
     resources :bitbucket, controller: :bitbucket, only: [ :create ]
+  end
+  namespace :webhooks do
+    resource :stripe, only: [ :create ], controller: :stripe
   end
   get "/privacy", to: "static#privacy"
   get "/terms", to: "static#terms"

--- a/db/migrate/20260819000000_add_billing_to_accounts.rb
+++ b/db/migrate/20260819000000_add_billing_to_accounts.rb
@@ -1,0 +1,12 @@
+class AddBillingToAccounts < ActiveRecord::Migration[7.2]
+  def change
+    add_column :accounts, :stripe_customer_id, :string
+    add_column :accounts, :stripe_subscription_id, :string
+    add_column :accounts, :plan, :integer, default: 0, null: false
+    add_column :accounts, :trial_ends_at, :datetime
+    add_column :accounts, :subscription_status, :string
+
+    add_index :accounts, :stripe_customer_id, unique: true
+    add_index :accounts, :stripe_subscription_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_08_16_000000) do
+ActiveRecord::Schema[7.2].define(version: 2026_08_19_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -31,8 +31,15 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_16_000000) do
     t.datetime "updated_at", null: false
     t.string "slug", null: false
     t.boolean "allow_mcp", default: true, null: false
+    t.string "stripe_customer_id"
+    t.string "stripe_subscription_id"
+    t.integer "plan", default: 0, null: false
+    t.datetime "trial_ends_at"
+    t.string "subscription_status"
     t.index ["owner_id"], name: "index_accounts_on_owner_id"
     t.index ["slug"], name: "index_accounts_on_slug", unique: true
+    t.index ["stripe_customer_id"], name: "index_accounts_on_stripe_customer_id", unique: true
+    t.index ["stripe_subscription_id"], name: "index_accounts_on_stripe_subscription_id", unique: true
   end
 
   create_table "active_storage_attachments", force: :cascade do |t|

--- a/spec/factories/accounts.rb
+++ b/spec/factories/accounts.rb
@@ -2,18 +2,25 @@
 #
 # Table name: accounts
 #
-#  id         :bigint           not null, primary key
-#  allow_mcp  :boolean          default(TRUE), not null
-#  name       :string           not null
-#  slug       :string           not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  owner_id   :bigint
+#  id                     :bigint           not null, primary key
+#  allow_mcp              :boolean          default(TRUE), not null
+#  name                   :string           not null
+#  plan                   :integer          default("free"), not null
+#  slug                   :string           not null
+#  subscription_status    :string
+#  trial_ends_at          :datetime
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  owner_id               :bigint
+#  stripe_customer_id     :string
+#  stripe_subscription_id :string
 #
 # Indexes
 #
-#  index_accounts_on_owner_id  (owner_id)
-#  index_accounts_on_slug      (slug) UNIQUE
+#  index_accounts_on_owner_id                (owner_id)
+#  index_accounts_on_slug                    (slug) UNIQUE
+#  index_accounts_on_stripe_customer_id      (stripe_customer_id) UNIQUE
+#  index_accounts_on_stripe_subscription_id  (stripe_subscription_id) UNIQUE
 #
 # Foreign Keys
 #

--- a/spec/models/concerns/billable_spec.rb
+++ b/spec/models/concerns/billable_spec.rb
@@ -1,0 +1,108 @@
+require 'rails_helper'
+
+RSpec.describe Billable, type: :model do
+  let(:account) { create(:account) }
+
+  describe '#plan_limit' do
+    it 'returns free limits for free accounts' do
+      expect(account.plan_limit(:clusters)).to eq(Billable::FREE_CLUSTER_LIMIT)
+      expect(account.plan_limit(:team_members)).to eq(Billable::FREE_TEAM_MEMBERS_LIMIT)
+    end
+
+    it 'returns unlimited for pro accounts' do
+      account.update!(plan: :pro)
+      expect(account.plan_limit(:clusters)).to eq(Float::INFINITY)
+      expect(account.plan_limit(:team_members)).to eq(Float::INFINITY)
+    end
+  end
+
+  describe '#within_plan_limit?' do
+    it 'allows the first cluster on a free plan' do
+      expect(account.within_plan_limit?(:clusters)).to be true
+    end
+
+    it 'blocks a second cluster on a free plan' do
+      create(:cluster, account: account)
+      expect(account.within_plan_limit?(:clusters)).to be false
+    end
+
+    it 'allows unlimited clusters on a pro plan' do
+      account.update!(plan: :pro)
+      3.times { create(:cluster, account: account) }
+      expect(account.within_plan_limit?(:clusters)).to be true
+    end
+
+    it 'blocks team members beyond the free limit' do
+      Billable::FREE_TEAM_MEMBERS_LIMIT.times do
+        user = create(:user)
+        create(:account_user, account: account, user: user)
+      end
+      expect(account.within_plan_limit?(:team_members)).to be false
+    end
+
+    it 'allows unlimited team members on a pro plan' do
+      account.update!(plan: :pro)
+      6.times do
+        user = create(:user)
+        create(:account_user, account: account, user: user)
+      end
+      expect(account.within_plan_limit?(:team_members)).to be true
+    end
+
+    it 'returns true for unknown resources' do
+      expect(account.within_plan_limit?(:unknown)).to be true
+    end
+  end
+
+  describe '#billable_clusters_count' do
+    it 'returns 0 when at or below the free limit' do
+      expect(account.billable_clusters_count).to eq(0)
+      create(:cluster, account: account)
+      expect(account.billable_clusters_count).to eq(0)
+    end
+
+    it 'returns the count beyond the free limit' do
+      3.times { create(:cluster, account: account) }
+      expect(account.billable_clusters_count).to eq(2)
+    end
+  end
+
+  describe '#active_subscription?' do
+    it 'returns true for active status' do
+      account.update!(subscription_status: "active")
+      expect(account.active_subscription?).to be true
+    end
+
+    it 'returns true for trialing status' do
+      account.update!(subscription_status: "trialing")
+      expect(account.active_subscription?).to be true
+    end
+
+    it 'returns false for canceled status' do
+      account.update!(subscription_status: "canceled")
+      expect(account.active_subscription?).to be false
+    end
+
+    it 'returns false when nil' do
+      expect(account.active_subscription?).to be false
+    end
+  end
+
+  describe '#needs_subscription?' do
+    it 'returns false with one cluster and no subscription' do
+      create(:cluster, account: account)
+      expect(account.needs_subscription?).to be false
+    end
+
+    it 'returns true with multiple clusters and no subscription' do
+      2.times { create(:cluster, account: account) }
+      expect(account.needs_subscription?).to be true
+    end
+
+    it 'returns false with multiple clusters and an active subscription' do
+      2.times { create(:cluster, account: account) }
+      account.update!(subscription_status: "active")
+      expect(account.needs_subscription?).to be false
+    end
+  end
+end

--- a/spec/requests/webhooks/stripe_controller_spec.rb
+++ b/spec/requests/webhooks/stripe_controller_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Webhooks::StripeController, type: :request do
+  let(:account) { create(:account) }
+  let(:webhook_secret) { "whsec_test_secret" }
+
+  before do
+    allow(Rails.configuration).to receive(:cloud_mode).and_return(true)
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with("STRIPE_WEBHOOK_SECRET").and_return(webhook_secret)
+  end
+
+  def post_webhook(event_type, data, metadata: {})
+    payload = { type: event_type, data: { object: data.merge(metadata: metadata) } }.to_json
+    timestamp = Time.now
+    signature = Stripe::Webhook::Signature.compute_signature(timestamp, payload, webhook_secret)
+    sig_header = "t=#{timestamp.to_i},v1=#{signature}"
+
+    post "/webhooks/stripe", params: payload, headers: {
+      "CONTENT_TYPE" => "application/json",
+      "HTTP_STRIPE_SIGNATURE" => sig_header
+    }
+  end
+
+  describe "checkout.session.completed" do
+    it "upgrades account to pro with subscription details" do
+      subscription = OpenStruct.new(id: "sub_123", status: "active", trial_end: nil)
+      allow(Stripe::Subscription).to receive(:retrieve).with("sub_123").and_return(subscription)
+
+      post_webhook("checkout.session.completed",
+        { subscription: "sub_123" },
+        metadata: { "account_id" => account.id.to_s })
+
+      expect(response).to have_http_status(:ok)
+      account.reload
+      expect(account.plan).to eq("pro")
+      expect(account.stripe_subscription_id).to eq("sub_123")
+      expect(account.subscription_status).to eq("active")
+    end
+
+    it "ignores unknown account" do
+      subscription = OpenStruct.new(id: "sub_123", status: "active", trial_end: nil)
+      allow(Stripe::Subscription).to receive(:retrieve).with("sub_123").and_return(subscription)
+
+      post_webhook("checkout.session.completed",
+        { subscription: "sub_123" },
+        metadata: { "account_id" => "999999" })
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "customer.subscription.updated" do
+    it "updates subscription status" do
+      account.update!(stripe_subscription_id: "sub_123", plan: :pro, subscription_status: "active")
+
+      post_webhook("customer.subscription.updated", { id: "sub_123", status: "past_due" })
+
+      expect(response).to have_http_status(:ok)
+      expect(account.reload.subscription_status).to eq("past_due")
+    end
+  end
+
+  describe "customer.subscription.deleted" do
+    it "downgrades account to free" do
+      account.update!(stripe_subscription_id: "sub_123", plan: :pro, subscription_status: "active")
+
+      post_webhook("customer.subscription.deleted", { id: "sub_123" })
+
+      expect(response).to have_http_status(:ok)
+      account.reload
+      expect(account.plan).to eq("free")
+      expect(account.subscription_status).to eq("canceled")
+      expect(account.stripe_subscription_id).to be_nil
+    end
+  end
+
+  describe "signature verification" do
+    it "returns bad_request with invalid signature" do
+      post "/webhooks/stripe", params: { type: "test" }.to_json, headers: {
+        "CONTENT_TYPE" => "application/json",
+        "HTTP_STRIPE_SIGNATURE" => "t=123,v1=invalid"
+      }
+
+      expect(response).to have_http_status(:bad_request)
+    end
+  end
+
+  describe "cloud_mode guard" do
+    it "returns not_found when not in cloud mode" do
+      allow(Rails.configuration).to receive(:cloud_mode).and_return(false)
+
+      post "/webhooks/stripe", params: {}.to_json, headers: { "CONTENT_TYPE" => "application/json" }
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- First cluster is free forever, additional clusters are $20/month each
- Stripe Checkout for upgrades, Customer Portal for subscription management
- Centralized plan enforcement via `Billable` concern and `BillableEnforcement` controller concern
- Webhook handler syncs subscription state, `StripeSyncUsageJob` keeps cluster quantity in sync
- Pricing plans section added to landing page
- Billing page added to account settings

## Setup
Requires three env vars:
```
STRIPE_SECRET_KEY=sk_test_xxx
STRIPE_WEBHOOK_SECRET=whsec_xxx
STRIPE_CLUSTER_PRICE_ID=price_xxx
```

And in Stripe Dashboard:
- One product with a per-unit price of $20/month
- Customer Portal enabled
- Webhook endpoint at `/webhooks/stripe`

## Test plan
- [x] Billable concern specs pass (17 examples)
- [ ] Verify free accounts are limited to 1 cluster
- [ ] Verify free accounts are limited to 5 team members
- [ ] Verify Stripe Checkout redirects correctly
- [ ] Verify webhook updates account plan/status
- [ ] Verify cluster create/destroy syncs quantity to Stripe
- [ ] Verify landing page pricing section renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)