### PR TITLE
fix: respect self-hosted GitLab host for git clone and registry push

### DIFF
--- a/app/jobs/projects/build_job.rb
+++ b/app/jobs/projects/build_job.rb
@@ -63,7 +63,7 @@ class Projects::BuildJob < ApplicationJob
   def project_git(project)
     project_credential_provider = project.project_credential_provider
     provider = project_credential_provider.provider
-    base_url = if provider.github?
+    base_url = project.repository_base_url.presence || if provider.github?
       "github.com"
     elsif provider.gitlab?
       "gitlab.com"

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -162,7 +162,7 @@ class Provider < ApplicationRecord
 
   def registry_base_url
     if github?
-      "ghcr.io"
+      enterprise? ? "containers.#{URI.parse(registry_url).host}" : "ghcr.io"
     elsif gitlab?
       enterprise? ? "registry.#{URI.parse(registry_url).host}" : "registry.gitlab.com"
     elsif container_registry?

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -164,7 +164,7 @@ class Provider < ApplicationRecord
     if github?
       "ghcr.io"
     elsif gitlab?
-      "registry.gitlab.com"
+      enterprise? ? "registry.#{URI.parse(registry_url).host}" : "registry.gitlab.com"
     elsif container_registry?
       registry_url
     else


### PR DESCRIPTION
- Projects::BuildJob#project_git built the git clone URL from a hardcoded gitlab.com/github.com/bitbucket.org instead of using project.repository_base_url.
- Provider#registry_base_url hardcoded registry.gitlab.com for any GitLab provider, regardless of enterprise?.

Both meant that self-hosted GitLab users (e.g. gitlab.example.com) would have their credential correctly configured in the UI, but builds would still silently clone from and push to gitlab.com/registry.gitlab.com, failing auth against those hosts.

This patches both to use the already-resolved enterprise host consistently.

Closes #692 