### PR TITLE
QoL: turbo_stream service updates, MCP modal, debug with AI

### DIFF
--- a/app/controllers/projects/services_controller.rb
+++ b/app/controllers/projects/services_controller.rb
@@ -27,10 +27,14 @@ class Projects::ServicesController < Projects::BaseController
 
   def update
     result = Services::Update.execute(service: @service, params: params)
-    if result.success?
-      redirect_to project_services_path(@project), notice: "Service will be updated on the next deploy."
-    else
-      redirect_to project_services_path(@project), alert: "Service could not be updated."
+    respond_to do |format|
+      if result.success?
+        format.turbo_stream
+        format.html { redirect_to project_services_path(@project), notice: "Service will be updated on the next deploy." }
+      else
+        format.turbo_stream { render turbo_stream: turbo_stream.replace("service-save-feedback", html: content_tag(:span, "Failed to save", class: "text-error text-sm")) }
+        format.html { redirect_to project_services_path(@project), alert: "Service could not be updated." }
+      end
     end
   end
 

--- a/app/views/accounts/edit.html.erb
+++ b/app/views/accounts/edit.html.erb
@@ -17,7 +17,7 @@
           </label>
         </div>
         <a class="text-sm text-gray-500 hover:text-gray-300 cursor-pointer block mb-4"
-           onclick="mcp_setup_modal.showModal()">
+           onclick="add_mcp_modal.showModal()">
           How do I add this as an MCP server?
         </a>
 
@@ -26,50 +26,7 @@
         </div>
       <% end %>
 
-      <dialog id="mcp_setup_modal" class="modal">
-        <div class="modal-box w-11/12 max-w-2xl bg-base-300">
-          <form method="dialog">
-            <button aria-label="Close modal" class="btn btn-circle btn-ghost btn-sm absolute right-2 top-2">
-              <iconify-icon icon="lucide:x" height="16"></iconify-icon>
-            </button>
-          </form>
-          <h3 class="mb-6 text-xl font-bold">Adding Canine as an MCP server</h3>
-          <p class="mb-6 text-sm text-base-content/70">Connect your AI tools to Canine to manage deployments, clusters, and more.</p>
-          <div class="mb-6">
-            <p class="text-sm text-base-content"><strong>Claude Code</strong></p>
-            <p class="mb-2 text-sm text-base-content/70">Run this in your terminal:</p>
-            <div class="flex items-center gap-2">
-              <input type="text" readonly value="claude mcp add --transport http canine <%= request.base_url %>/mcp" class="input input-bordered input-sm flex-1 font-mono text-xs">
-              <button type="button" class="btn btn-sm btn-square btn-ghost" onclick="navigator.clipboard.writeText(this.dataset.clipboardText)" data-clipboard-text="claude mcp add --transport http canine <%= request.base_url %>/mcp">
-                <iconify-icon icon="lucide:copy" height="16"></iconify-icon>
-              </button>
-            </div>
-          </div>
-          <div class="mb-6">
-            <p class="text-sm text-base-content"><strong>Cursor</strong></p>
-            <p class="mb-2 text-sm text-base-content/70">Go to <strong>Settings → MCP</strong> and add a new server with this URL:</p>
-            <div class="flex items-center gap-2">
-              <input type="text" readonly value="<%= request.base_url %>/mcp" class="input input-bordered input-sm flex-1 font-mono text-xs">
-              <button type="button" class="btn btn-sm btn-square btn-ghost" onclick="navigator.clipboard.writeText(this.dataset.clipboardText)" data-clipboard-text="<%= request.base_url %>/mcp">
-                <iconify-icon icon="lucide:copy" height="16"></iconify-icon>
-              </button>
-            </div>
-          </div>
-          <div class="mb-2">
-            <p class="text-sm text-base-content"><strong>Claude Desktop</strong> &amp; other MCP clients</p>
-            <p class="mb-2 text-sm text-base-content/70">Use the server URL:</p>
-            <div class="flex items-center gap-2">
-              <input type="text" readonly value="<%= request.base_url %>/mcp" class="input input-bordered input-sm flex-1 font-mono text-xs">
-              <button type="button" class="btn btn-sm btn-square btn-ghost" onclick="navigator.clipboard.writeText(this.dataset.clipboardText)" data-clipboard-text="<%= request.base_url %>/mcp">
-                <iconify-icon icon="lucide:copy" height="16"></iconify-icon>
-              </button>
-            </div>
-          </div>
-        </div>
-        <form method="dialog" class="modal-backdrop">
-          <button>close</button>
-        </form>
-      </dialog>
+      <%= render "shared/add_mcp_modal" %>
     </div>
   </div>
 <% end %>

--- a/app/views/log_outputs/_pod_logs.html.erb
+++ b/app/views/log_outputs/_pod_logs.html.erb
@@ -5,14 +5,7 @@
   <div class="flex space-x-2 items-center mb-2">
     <h4 class="text-md font-medium"><%= params[:id] %></h4>
     <div class="badge badge-success">• LIVE</div>
-    <div class="ml-auto">
-      <button class="btn btn-ghost btn-sm gap-1" onclick="add_mcp_modal.showModal()">
-        <iconify-icon icon="lucide:cpu" height="14"></iconify-icon>
-        Debug with AI
-      </button>
-    </div>
   </div>
-  <%= render "shared/add_mcp_modal" %>
   <% if defined?(error) && error.present? %>
     <div class="alert alert-warning my-5">
       <iconify-icon icon="lucide:alert-triangle" height="20"></iconify-icon>
@@ -39,4 +32,12 @@
         %><%= ansi_to_tailwind(event_logs.force_encoding("UTF-8")).html_safe %></pre>
     </div>
   </div>
+
+  <div class="flex justify-end mt-4">
+    <button class="btn btn-ghost btn-sm gap-1" onclick="add_mcp_modal.showModal()">
+      <iconify-icon icon="lucide:cpu" height="14"></iconify-icon>
+      Debug with AI
+    </button>
+  </div>
+  <%= render "shared/add_mcp_modal" %>
 </div>

--- a/app/views/log_outputs/_pod_logs.html.erb
+++ b/app/views/log_outputs/_pod_logs.html.erb
@@ -18,10 +18,7 @@
     </div>
   </div>
   <div class="flex justify-end mt-2">
-    <button class="btn btn-ghost btn-sm gap-1" onclick="add_mcp_modal.showModal()">
-      <iconify-icon icon="lucide:cpu" height="14"></iconify-icon>
-      Debug with AI
-    </button>
+    <span class="text-sm text-base-content/50">Need help debugging? <a class="underline cursor-pointer hover:text-base-content/70" onclick="add_mcp_modal.showModal()">Add our MCP server</a></span>
   </div>
   <%= render "shared/add_mcp_modal" %>
 

--- a/app/views/log_outputs/_pod_logs.html.erb
+++ b/app/views/log_outputs/_pod_logs.html.erb
@@ -17,6 +17,13 @@
       <pre class="text-sm font-mono whitespace-pre-wrap" id="logs"><%= ansi_to_tailwind(logs.force_encoding("UTF-8")).html_safe || "No logs yet..." %></pre>
     </div>
   </div>
+  <div class="flex justify-end mt-2">
+    <button class="btn btn-ghost btn-sm gap-1" onclick="add_mcp_modal.showModal()">
+      <iconify-icon icon="lucide:cpu" height="14"></iconify-icon>
+      Debug with AI
+    </button>
+  </div>
+  <%= render "shared/add_mcp_modal" %>
 
   <div class="flex space-x-2 items-center mt-8">
     <h4 class="text-lg font-medium">Start Up Logs</h4>
@@ -32,12 +39,4 @@
         %><%= ansi_to_tailwind(event_logs.force_encoding("UTF-8")).html_safe %></pre>
     </div>
   </div>
-
-  <div class="flex justify-end mt-4">
-    <button class="btn btn-ghost btn-sm gap-1" onclick="add_mcp_modal.showModal()">
-      <iconify-icon icon="lucide:cpu" height="14"></iconify-icon>
-      Debug with AI
-    </button>
-  </div>
-  <%= render "shared/add_mcp_modal" %>
 </div>

--- a/app/views/log_outputs/_pod_logs.html.erb
+++ b/app/views/log_outputs/_pod_logs.html.erb
@@ -5,7 +5,14 @@
   <div class="flex space-x-2 items-center mb-2">
     <h4 class="text-md font-medium"><%= params[:id] %></h4>
     <div class="badge badge-success">• LIVE</div>
+    <div class="ml-auto">
+      <button class="btn btn-ghost btn-sm gap-1" onclick="add_mcp_modal.showModal()">
+        <iconify-icon icon="lucide:cpu" height="14"></iconify-icon>
+        Debug with AI
+      </button>
+    </div>
   </div>
+  <%= render "shared/add_mcp_modal" %>
   <% if defined?(error) && error.present? %>
     <div class="alert alert-warning my-5">
       <iconify-icon icon="lucide:alert-triangle" height="20"></iconify-icon>

--- a/app/views/projects/services/_advanced.html.erb
+++ b/app/views/projects/services/_advanced.html.erb
@@ -47,13 +47,14 @@
         </label>
       </div>
 
-      <div class="form-footer mt-6 flex gap-2">
+      <div class="form-footer mt-6 flex items-center gap-2">
         <%= form.submit @service.pod_yaml.present? ? "Update Pod Template" : "Save Pod Template", class: "btn btn-primary", data: { turbo_submits_with: "Saving..." } %>
         <button type="button"
                 class="btn btn-outline"
                 data-action="click->content-toggle#cancelEdit">
           Cancel
         </button>
+        <span id="service-save-feedback"></span>
       </div>
     <% end %>
   </div>

--- a/app/views/projects/services/_overview.html.erb
+++ b/app/views/projects/services/_overview.html.erb
@@ -51,8 +51,9 @@
         <%= render "shared/partials/markdown_editor", form: form %>
       </div>
     </div>
-    <div class="form-footer">
+    <div class="form-footer flex items-center gap-3">
       <%= form.submit class: "btn btn-primary", data: { turbo_submits_with: "Saving..." } %>
+      <span id="service-save-feedback"></span>
     </div>
   <% end %>
 </div>

--- a/app/views/projects/services/update.turbo_stream.erb
+++ b/app/views/projects/services/update.turbo_stream.erb
@@ -1,0 +1,6 @@
+<%= turbo_stream.replace "service-save-feedback" do %>
+  <span id="service-save-feedback" class="inline-flex items-center gap-1 text-success text-sm animate-fade-out">
+    <iconify-icon icon="lucide:check-circle" height="16"></iconify-icon>
+    Saved
+  </span>
+<% end %>

--- a/app/views/shared/_add_mcp_modal.html.erb
+++ b/app/views/shared/_add_mcp_modal.html.erb
@@ -1,0 +1,44 @@
+<dialog id="add_mcp_modal" class="modal">
+  <div class="modal-box w-11/12 max-w-2xl bg-base-300">
+    <form method="dialog">
+      <button aria-label="Close modal" class="btn btn-circle btn-ghost btn-sm absolute right-2 top-2">
+        <iconify-icon icon="lucide:x" height="16"></iconify-icon>
+      </button>
+    </form>
+    <h3 class="mb-4 text-xl font-bold">Debug with AI</h3>
+    <p class="mb-6 text-sm text-base-content/70">Connect your AI tools to Canine to read logs, manage deployments, and debug issues — all from your editor.</p>
+    <div class="mb-6">
+      <p class="text-sm text-base-content"><strong>Claude Code</strong></p>
+      <p class="mb-2 text-sm text-base-content/70">Run this in your terminal:</p>
+      <div class="flex items-center gap-2">
+        <input type="text" readonly value="claude mcp add --transport http canine <%= request.base_url %>/mcp" class="input input-bordered input-sm flex-1 font-mono text-xs">
+        <button type="button" class="btn btn-sm btn-square btn-ghost" onclick="navigator.clipboard.writeText(this.dataset.clipboardText)" data-clipboard-text="claude mcp add --transport http canine <%= request.base_url %>/mcp">
+          <iconify-icon icon="lucide:copy" height="16"></iconify-icon>
+        </button>
+      </div>
+    </div>
+    <div class="mb-6">
+      <p class="text-sm text-base-content"><strong>Cursor</strong></p>
+      <p class="mb-2 text-sm text-base-content/70">Go to <strong>Settings → MCP</strong> and add a new server with this URL:</p>
+      <div class="flex items-center gap-2">
+        <input type="text" readonly value="<%= request.base_url %>/mcp" class="input input-bordered input-sm flex-1 font-mono text-xs">
+        <button type="button" class="btn btn-sm btn-square btn-ghost" onclick="navigator.clipboard.writeText(this.dataset.clipboardText)" data-clipboard-text="<%= request.base_url %>/mcp">
+          <iconify-icon icon="lucide:copy" height="16"></iconify-icon>
+        </button>
+      </div>
+    </div>
+    <div class="mb-2">
+      <p class="text-sm text-base-content"><strong>Claude Desktop</strong> &amp; other MCP clients</p>
+      <p class="mb-2 text-sm text-base-content/70">Use the server URL:</p>
+      <div class="flex items-center gap-2">
+        <input type="text" readonly value="<%= request.base_url %>/mcp" class="input input-bordered input-sm flex-1 font-mono text-xs">
+        <button type="button" class="btn btn-sm btn-square btn-ghost" onclick="navigator.clipboard.writeText(this.dataset.clipboardText)" data-clipboard-text="<%= request.base_url %>/mcp">
+          <iconify-icon icon="lucide:copy" height="16"></iconify-icon>
+        </button>
+      </div>
+    </div>
+  </div>
+  <form method="dialog" class="modal-backdrop">
+    <button>close</button>
+  </form>
+</dialog>

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -31,6 +31,15 @@ module.exports = {
       fontFamily: {
         body: ["DM Sans", "sans-serif"],
       },
+      keyframes: {
+        'fade-out': {
+          '0%, 70%': { opacity: '1' },
+          '100%': { opacity: '0' },
+        },
+      },
+      animation: {
+        'fade-out': 'fade-out 3s ease-out forwards',
+      },
     },
     container: {
       center: true,


### PR DESCRIPTION
## Summary
- Service update now responds with turbo_stream for inline save feedback
- Extract MCP setup modal into shared partial for reuse
- Add "Debug with AI" button to pod logs that opens MCP modal
- Add fade-out animation keyframe to Tailwind config

## Test plan
- [ ] Verify service overview and advanced forms show save feedback inline
- [ ] Verify MCP modal works from account edit and pod logs pages
- [ ] Verify fade-out animation works on feedback messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)