### PR TITLE
Add summary to doctor checks and remove discovering phase

### DIFF
--- a/app/actions/projects/doctor.rb
+++ b/app/actions/projects/doctor.rb
@@ -12,27 +12,20 @@ class Projects::Doctor
     # Determine which checks are applicable
     applicable = applicable_checks(project)
 
-    # Phase 1: Open modal with discovering state
-    broadcast_discovering(project)
-    sleep 1
-
-    # Phase 2: Reveal each check item one by one
+    # Show all check items immediately
     applicable.each do |name|
       broadcast_append_check(project, name)
-      sleep 0.3
     end
 
-    # Clear the discovering spinner
-    broadcast_clear_discovering(project)
-    sleep 0.3
-
-    # Phase 3: Run and resolve each check
+    # Run and resolve each check
     checks = {}
     applicable.each do |name|
       checks[name] = run_check(project, name) { send(:"check_#{name}", project, user) }
     end
 
     context.checks = checks
+
+    broadcast_summary(project, checks)
   end
 
   private
@@ -45,19 +38,6 @@ class Projects::Doctor
     checks
   end
 
-  def self.broadcast_discovering(project)
-    html = '<div id="doctor-discovering" class="flex items-center gap-2 text-sm text-base-content/60">' \
-           '<iconify-icon icon="lucide:loader-circle" height="16" class="text-primary animate-spin"></iconify-icon>' \
-           'Analyzing project configuration...' \
-           '</div>'
-
-    Turbo::StreamsChannel.broadcast_update_to(
-      project,
-      target: "doctor-checks",
-      html: html
-    )
-  end
-
   def self.broadcast_append_check(project, name)
     Turbo::StreamsChannel.broadcast_append_to(
       project,
@@ -67,10 +47,15 @@ class Projects::Doctor
     )
   end
 
-  def self.broadcast_clear_discovering(project)
-    Turbo::StreamsChannel.broadcast_remove_to(
+  def self.broadcast_summary(project, checks)
+    total_count = checks.values.size
+    failed_count = checks.values.count { |c| c[:status] == "error" }
+
+    Turbo::StreamsChannel.broadcast_append_to(
       project,
-      target: "doctor-discovering"
+      target: "doctor-checks",
+      partial: "shared/doctor_summary",
+      locals: { total_count: total_count, failed_count: failed_count }
     )
   end
 

--- a/app/views/shared/_doctor_summary.html.erb
+++ b/app/views/shared/_doctor_summary.html.erb
@@ -3,7 +3,10 @@
   <div class="flex items-center gap-2">
     <% if failed_count > 0 %>
       <iconify-icon icon="lucide:triangle-alert" height="20" class="text-warning"></iconify-icon>
-      <span class="font-medium"><%= failed_count %> of <%= total_count %> check<%= total_count == 1 ? "" : "s" %> failed</span>
+      <div>
+        <span class="font-medium"><%= failed_count %> of <%= total_count %> check<%= total_count == 1 ? "" : "s" %> failed</span>
+        <p class="text-sm text-base-content/60 mt-0.5">Builds and deploys may not work until these issues are resolved.</p>
+      </div>
     <% else %>
       <iconify-icon icon="lucide:circle-check" height="20" class="text-success"></iconify-icon>
       <span class="font-medium">All checks passed</span>

--- a/app/views/shared/_doctor_summary.html.erb
+++ b/app/views/shared/_doctor_summary.html.erb
@@ -1,0 +1,12 @@
+<div id="doctor-summary" class="mt-1 p-3 rounded-lg border animate-fade-in
+  <%= failed_count > 0 ? 'border-error/30 bg-error/5' : 'border-success/30 bg-success/5' %>">
+  <div class="flex items-center gap-2">
+    <% if failed_count > 0 %>
+      <iconify-icon icon="lucide:triangle-alert" height="20" class="text-warning"></iconify-icon>
+      <span class="font-medium"><%= failed_count %> of <%= total_count %> check<%= total_count == 1 ? "" : "s" %> failed</span>
+    <% else %>
+      <iconify-icon icon="lucide:circle-check" height="20" class="text-success"></iconify-icon>
+      <span class="font-medium">All checks passed</span>
+    <% end %>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- Removed the "Analyzing project configuration..." discovering spinner and staggered reveal delays — checks now appear immediately when diagnostics run
- Added a summary banner after all checks complete showing "All checks passed" (green) or "X of Y checks failed" (warning)

## Test plan
- [ ] Run diagnostics on a project — checks should appear immediately without the discovering spinner
- [ ] Verify summary shows "All checks passed" when everything passes
- [ ] Verify summary shows correct failure count when checks fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)