### PR TITLE
Add image check for container registry projects

### DIFF
--- a/app/actions/projects/doctor.rb
+++ b/app/actions/projects/doctor.rb
@@ -32,9 +32,13 @@ class Projects::Doctor
 
   def self.applicable_checks(project)
     checks = [ :cluster ]
-    checks << :source if project.git?
-    checks << :registry if project.build_provider.present?
-    checks << :build_cloud if project.build_configuration&.build_cloud.present?
+    if project.git?
+      checks << :source
+      checks << :registry if project.build_provider.present?
+      checks << :build_cloud if project.build_configuration&.build_cloud.present?
+    else
+      checks << :image
+    end
     checks
   end
 
@@ -137,6 +141,43 @@ class Projects::Doctor
   rescue StandardError => e
     { status: "error", message: "Registry check failed: #{e.message}",
       hint: "Ensure the registry URL is correct and the registry service is available." }
+  end
+
+  def self.check_image(project, _user)
+    image = project.full_image_name
+    tag = project.branch.presence || "latest"
+    full_ref = "#{image}:#{tag}"
+
+    if project.public_image?
+      _, _, status = Open3.capture3("docker", "manifest", "inspect", full_ref)
+    else
+      provider = project.project_credential_provider&.provider
+      if provider.blank?
+        return { status: "error", message: "No credential provider configured",
+                 hint: "Add a container registry credential provider to pull private images." }
+      end
+
+      DockerCli.with_registry_auth(
+        registry_url: provider.registry_base_url,
+        username: provider.username,
+        password: provider.access_token
+      ) do
+        _, _, status = Open3.capture3("docker", "manifest", "inspect", full_ref)
+      end
+    end
+
+    if status.success?
+      { status: "ok", message: "Image #{full_ref} is accessible" }
+    else
+      { status: "error", message: "Image #{full_ref} not found",
+        hint: "Verify the image name and tag exist in the registry. Check that credentials have pull access." }
+    end
+  rescue DockerCli::AuthenticationError => e
+    { status: "error", message: "Registry authentication failed: #{e.message}",
+      hint: "The registry credentials are invalid. Update them in your provider settings." }
+  rescue StandardError => e
+    { status: "error", message: "Image check failed: #{e.message}",
+      hint: "Ensure Docker is available and the registry is reachable." }
   end
 
   def self.check_build_cloud(project, user)

--- a/app/views/projects/_layout.html.erb
+++ b/app/views/projects/_layout.html.erb
@@ -63,7 +63,7 @@
           <li>
             <%= button_to doctor_project_url(project), data: { disable_with: "Running..." } do %>
               <iconify-icon icon="lucide:stethoscope"></iconify-icon>
-              Diagnostics
+              Run Diagnostics
             <% end %>
           </li>
         </ul>


### PR DESCRIPTION
## Summary
- Container registry projects now get an `:image` check (via `docker manifest inspect`) instead of source/registry/build cloud checks
- Handles both public images and private images (authenticates with registry credentials)
- Renamed "Diagnostics" button to "Run Diagnostics" in the project dropdown

## Test plan
- [ ] Run diagnostics on a container registry project — should show cluster + image checks
- [ ] Run diagnostics on a git project — should still show cluster + source + registry checks as before
- [ ] Verify public image check works (e.g. `nginx:latest`)
- [ ] Verify private image check authenticates and validates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)