### PR TITLE
Fix add-on uninstall hanging due to TypeError

### DIFF
--- a/app/actions/add_ons/uninstall_helm_chart.rb
+++ b/app/actions/add_ons/uninstall_helm_chart.rb
@@ -6,10 +6,7 @@ class AddOns::UninstallHelmChart
     connection = context.connection
     add_on = connection.add_on
     client = K8::Helm::Client.connect(connection, Cli::RunAndLog.new(add_on))
-    charts = client.ls
-    if charts.any? { |chart| chart['name'] == add_on.name }
-      client.uninstall(add_on.name, namespace: add_on.name)
-    end
+    client.uninstall(add_on.name, namespace: add_on.namespace)
 
     client = K8::Client.new(connection)
     if add_on.managed_namespace? && (namespace = client.get_namespaces.find { |n| n.metadata.name == add_on.namespace }).present?

--- a/spec/actions/add_ons/uninstall_helm_chart_spec.rb
+++ b/spec/actions/add_ons/uninstall_helm_chart_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe AddOns::UninstallHelmChart do
     allow(K8::Kubectl).to receive(:new).and_return(kubectl)
     allow(kubectl).to receive(:apply_yaml)
     allow(K8::Helm::Client).to receive(:connect).and_return(helm_client)
-    allow(helm_client).to receive(:ls).and_return([])
+    allow(helm_client).to receive(:uninstall)
     allow(K8::Client).to receive(:new).and_return(client)
     allow(client).to receive(:get_namespaces).and_return([])
   end


### PR DESCRIPTION
## Summary
- `UninstallHelmChart` used `Cli::RunAndLog` which returns `Process::Status`, but `client.ls` tried to `YAML.safe_load` it, causing `TypeError: no implicit conversion of Process::Status into String`
- Removed the unnecessary `ls` pre-check — `client.uninstall` already handles the "release not found" case gracefully
- Fixed `namespace:` parameter which was incorrectly set to `add_on.name` instead of `add_on.namespace`

## Test plan
- [ ] Delete an add-on and verify it uninstalls successfully
- [ ] Delete an add-on whose helm release was already removed manually — should still complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)