### PR TITLE
Restore reverted changes from main

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -114,6 +114,7 @@ gem "ruby-saml", "~> 1.17"
 gem "mcp", "~> 0.4.0"
 
 gem "doorkeeper", "~> 5.8"
+gem "doorkeeper-openid_connect", "~> 1.8"
 
 gem "rotp", "~> 6.3"
 gem "rqrcode", "~> 2.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,6 +186,10 @@ GEM
     domain_name (0.6.20240107)
     doorkeeper (5.9.3)
       railties (>= 5)
+    doorkeeper-openid_connect (1.10.5)
+      doorkeeper (>= 5.5, < 6.0)
+      jwt (>= 2.5)
+      ostruct (>= 0.5)
     dotenv (3.2.0)
     drb (2.2.3)
     dry-configurable (1.4.0)
@@ -763,6 +767,7 @@ DEPENDENCIES
   devise (~> 4.9)
   devise_invitable (~> 2.0)
   doorkeeper (~> 5.8)
+  doorkeeper-openid_connect (~> 1.8)
   dotenv (~> 3.1)
   factory_bot_rails
   faker (~> 3.8.0)

--- a/app/actions/add_ons/create.rb
+++ b/app/actions/add_ons/create.rb
@@ -14,6 +14,7 @@ class AddOns::Create
       :version,
       :repository_url,
       :artifact_hub_package_id,
+      :internal,
       metadata: {},
       values: {}
     )

--- a/app/actions/add_ons/fetch_chart_details_from_repository_url.rb
+++ b/app/actions/add_ons/fetch_chart_details_from_repository_url.rb
@@ -7,6 +7,75 @@ module AddOns
 
     executed do |context|
       repo_url = context.repo_url
+
+      if repo_url.start_with?("oci://")
+        fetch_oci_tags(context, repo_url)
+      else
+        fetch_http_index(context, repo_url)
+      end
+    end
+
+    def self.fetch_oci_tags(context, repo_url)
+      # Parse OCI URL: oci://registry/path/to/chart -> registry, path/to/chart
+      uri_part = repo_url.sub("oci://", "")
+      parts = uri_part.split("/")
+      registry = parts.first
+      image_path = parts[1..].join("/")
+      chart_name = parts.last
+
+      begin
+        token = fetch_oci_token(registry, image_path)
+        headers = { "Accept" => "application/json" }
+        headers["Authorization"] = "Bearer #{token}" if token
+
+        tags_url = "https://#{registry}/v2/#{image_path}/tags/list"
+        response = HTTParty.get(tags_url, timeout: 10, headers: headers)
+
+        unless response.success?
+          context.fail_and_return!("Failed to fetch OCI tags (#{response.code}). The registry may require authentication.")
+          return
+        end
+
+        data = JSON.parse(response.body)
+        tags = data["tags"] || []
+
+        # Sort tags by semver descending, falling back to string sort
+        sorted_tags = tags.sort_by { |t| Gem::Version.new(t) rescue Gem::Version.new("0") }.reverse
+
+        context.charts = { chart_name => sorted_tags }
+      rescue HTTParty::Error, Net::OpenTimeout, SocketError => e
+        context.fail_and_return!("Failed to fetch OCI tags: #{e.message}")
+      rescue JSON::ParserError => e
+        context.fail_and_return!("Invalid response from OCI registry: #{e.message}")
+      rescue StandardError => e
+        context.fail_and_return!("An error occurred: #{e.message}")
+      end
+    end
+
+    # Docker v2 registries require a bearer token even for public images.
+    # We request an anonymous token via the WWW-Authenticate challenge.
+    def self.fetch_oci_token(registry, image_path)
+      challenge_response = HTTParty.get("https://#{registry}/v2/", timeout: 5)
+      return nil if challenge_response.success?
+
+      www_auth = challenge_response.headers["www-authenticate"]
+      return nil unless www_auth
+
+      # Parse: Bearer realm="https://...",service="...",scope="..."
+      realm = www_auth[/realm="([^"]+)"/, 1]
+      service = www_auth[/service="([^"]+)"/, 1]
+      return nil unless realm
+
+      token_url = "#{realm}?service=#{service}&scope=repository:#{image_path}:pull"
+      token_response = HTTParty.get(token_url, timeout: 5)
+      return nil unless token_response.success?
+
+      JSON.parse(token_response.body)["token"]
+    rescue StandardError
+      nil
+    end
+
+    def self.fetch_http_index(context, repo_url)
       index_url = "#{repo_url.chomp('/')}/index.yaml"
 
       begin
@@ -14,12 +83,14 @@ module AddOns
 
         unless response.success?
           context.fail_and_return!("Failed to fetch repository index: #{response.code}")
+          return
         end
 
         index_data = YAML.safe_load(response.body)
 
         unless index_data.is_a?(Hash) && index_data['entries'].is_a?(Hash)
           context.fail_and_return!("Invalid repository index format")
+          return
         end
 
         # Extract chart names and their available versions

--- a/app/actions/projects/create.rb
+++ b/app/actions/projects/create.rb
@@ -24,7 +24,8 @@ class Projects::Create
       :predeploy_command,
       :project_fork_status,
       :project_fork_cluster_id,
-      :public_image_url
+      :public_image_url,
+      :internal
     )
   end
 

--- a/app/actions/services/update.rb
+++ b/app/actions/services/update.rb
@@ -6,6 +6,7 @@ class Services::Update
 
   executed do |context|
     was_public = context.service.allow_public_networking?
+    was_internal = context.service.internal?
 
     context.service.update(Service.permitted_params(context.params))
     if context.service.cron_job? && context.params[:service][:cron_schedule].present?
@@ -15,6 +16,16 @@ class Services::Update
 
     if !was_public && context.service.allow_public_networking?
       Domains::AttachAutoManagedDomain.execute(service: context.service)
+    end
+
+    # Update OAuth application redirect URI when domain changes
+    if context.service.internal? && context.service.oauth_application.present? && context.service.auto_domain.present?
+      context.service.oauth_application.update(redirect_uri: "https://#{context.service.auto_domain}/oauth2/callback")
+    end
+
+    # Schedule cleanup of auth proxy K8s resources when internal is toggled off
+    if was_internal && !context.service.internal?
+      Services::CleanupAuthProxyJob.perform_later(context.service)
     end
 
     context.service.updated!

--- a/app/controllers/add_ons/endpoints_controller.rb
+++ b/app/controllers/add_ons/endpoints_controller.rb
@@ -20,13 +20,19 @@ class AddOns::EndpointsController < AddOns::BaseController
     @errors << 'Invalid domain format' unless domains.all? { |domain| valid_domain?(domain) }
     @errors << 'Invalid port' unless @endpoint.spec.ports.map(&:port).include?(params[:port].to_i)
     kubectl = K8::Kubectl.new(active_connection)
+    port = params[:port].to_i
+
+    if @add_on.internal? && @add_on.oauth_application.present?
+      # Update OAuth redirect URI with the first domain
+      @add_on.oauth_application.update(redirect_uri: "https://#{domains.first}/oauth2/callback")
+
+      kubectl.apply_yaml(
+        K8::AddOns::AuthProxy.new(@add_on, @endpoint, port, domains).to_yaml
+      )
+    end
+
     kubectl.apply_yaml(
-      K8::AddOns::Ingress.new(
-        @add_on,
-        @endpoint,
-        params[:port].to_i,
-        domains,
-      ).to_yaml
+      K8::AddOns::Ingress.new(@add_on, @endpoint, port, domains).to_yaml
     )
     if @errors.empty?
       @ingresses = @service.get_ingresses

--- a/app/javascript/controllers/add_ons/oci_registry_controller.js
+++ b/app/javascript/controllers/add_ons/oci_registry_controller.js
@@ -1,0 +1,117 @@
+import { Controller } from "@hotwired/stimulus"
+import { debounce } from "../../utils"
+
+export default class extends Controller {
+  static targets = [
+    "ociUrl",
+    "loading",
+    "error",
+    "errorMessage"
+  ]
+
+  connect() {
+    this.debouncedFetchVersions = debounce(this.fetchVersions.bind(this), 500)
+  }
+
+  onInput() {
+    const ociUrl = this.ociUrlTarget.value.trim()
+
+    // Set the repository_url hidden field
+    const repositoryUrlInput = document.querySelector('input[name="add_on[repository_url]"]')
+    if (repositoryUrlInput) {
+      repositoryUrlInput.value = ociUrl
+    }
+
+    // Set chart_url from OCI URL path (e.g., oci://ghcr.io/org/repo/chart -> org-repo/chart)
+    const chartUrlInput = document.querySelector('input[name="add_on[chart_url]"]')
+    if (chartUrlInput && ociUrl.startsWith('oci://')) {
+      const parts = ociUrl.replace('oci://', '').split('/').filter(p => p.length > 0)
+      if (parts.length >= 2) {
+        const chartName = parts[parts.length - 1]
+        const repoAlias = parts.slice(1, -1).join('-') || parts[0].replace(/\./g, '-')
+        chartUrlInput.value = `${repoAlias}/${chartName}`
+        chartUrlInput.dispatchEvent(new Event('change'))
+      }
+    }
+
+    this.debouncedFetchVersions()
+  }
+
+  async fetchVersions() {
+    const ociUrl = this.ociUrlTarget.value.trim()
+
+    if (!ociUrl) {
+      return
+    }
+
+    // Validate OCI URL format
+    if (!ociUrl.startsWith('oci://')) {
+      this.showError("URL must start with oci://")
+      return
+    }
+
+    const parts = ociUrl.replace('oci://', '').split('/').filter(p => p.length > 0)
+    if (parts.length < 2) {
+      this.showError("Invalid OCI URL format")
+      return
+    }
+
+    this.showLoading()
+    this.hideError()
+
+    try {
+      const response = await fetch('/add_ons/fetch_helm_repository_index', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-Token': document.querySelector('[name="csrf-token"]').content
+        },
+        body: JSON.stringify({ repo_url: ociUrl })
+      })
+
+      if (!response.ok) {
+        const errorData = await response.json()
+        throw new Error(errorData.error || 'Failed to fetch OCI tags')
+      }
+
+      const data = await response.json()
+      const versions = Object.values(data.charts)[0]
+
+      if (versions && versions.length > 0) {
+        // Populate the version selector directly
+        const versionSelectorController = this.application.getControllerForElementAndIdentifier(
+          document.querySelector('[data-controller*="add-ons--version-selector"]'),
+          'add-ons--version-selector'
+        )
+        if (versionSelectorController) {
+          versionSelectorController.populateVersionSelector(versions)
+          versionSelectorController.showVersionSelector()
+          versionSelectorController.enableSubmitButton()
+        }
+        this.hideLoading()
+      } else {
+        throw new Error('No versions found in OCI registry')
+      }
+    } catch (error) {
+      this.hideLoading()
+      this.showError(error.message)
+    }
+  }
+
+  showLoading() {
+    this.loadingTarget.classList.remove('hidden')
+  }
+
+  hideLoading() {
+    this.loadingTarget.classList.add('hidden')
+  }
+
+  showError(message) {
+    this.errorMessageTarget.textContent = message
+    this.errorTarget.classList.remove('hidden')
+  }
+
+  hideError() {
+    this.errorTarget.classList.add('hidden')
+  }
+}

--- a/app/jobs/add_ons/cleanup_auth_proxy_job.rb
+++ b/app/jobs/add_ons/cleanup_auth_proxy_job.rb
@@ -1,0 +1,14 @@
+class AddOns::CleanupAuthProxyJob < ApplicationJob
+  def perform(add_on)
+    connection = K8::Connection.new(add_on, nil, allow_anonymous: true)
+    kubectl = K8::Kubectl.new(connection)
+
+    # Find and delete all auth-proxy labeled resources in the add-on namespace
+    %w[deployment service].each do |resource_type|
+      result = kubectl.call(%w[-n] + [ add_on.name, "get", resource_type, "-l", "caninemanaged=auth-proxy", "-o", "name" ])
+      result.to_s.split("\n").each do |resource_name|
+        kubectl.call(%w[-n] + [ add_on.name, "delete", resource_name, "--ignore-not-found" ]) if resource_name.present?
+      end
+    end
+  end
+end

--- a/app/jobs/services/cleanup_auth_proxy_job.rb
+++ b/app/jobs/services/cleanup_auth_proxy_job.rb
@@ -1,0 +1,11 @@
+class Services::CleanupAuthProxyJob < ApplicationJob
+  def perform(service)
+    project = service.project
+    connection = K8::Connection.new(project, nil, allow_anonymous: true)
+    kubectl = K8::Kubectl.new(connection)
+
+    %w[deployment service].each do |resource_type|
+      kubectl.call(%w[-n] + [ project.namespace, "delete", resource_type, "#{service.name}-auth-proxy", "--ignore-not-found" ])
+    end
+  end
+end

--- a/app/models/add_on.rb
+++ b/app/models/add_on.rb
@@ -5,6 +5,7 @@
 #  id                      :bigint           not null, primary key
 #  chart_type              :string
 #  chart_url               :string
+#  internal                :boolean          default(FALSE)
 #  managed_namespace       :boolean          default(TRUE)
 #  metadata                :jsonb
 #  name                    :string           not null
@@ -41,6 +42,9 @@ class AddOn < ApplicationRecord
   end
 
   has_one :account, through: :cluster
+  has_one :oauth_application, class_name: "Doorkeeper::Application", dependent: :destroy
+
+  after_save :manage_oauth_application, if: :saved_change_to_internal?
 
   enum :status, {
     installing: 0,
@@ -77,6 +81,10 @@ class AddOn < ApplicationRecord
     chart_url&.split('/')&.first
   end
 
+  def auth_proxy_cookie_secret
+    oauth_application&.secret&.first(32)
+  end
+
   protected
 
   def validate_keys(required_keys)
@@ -84,6 +92,24 @@ class AddOn < ApplicationRecord
 
     if missing_keys.any?
       errors.add(:metadata, "is missing required keys: #{missing_keys.join(', ')}")
+    end
+  end
+
+  private
+
+  def manage_oauth_application
+    if internal?
+      return if oauth_application.present?
+
+      create_oauth_application!(
+        name: "Auth Proxy: #{name}",
+        redirect_uri: "https://#{name}.canine.sh/oauth2/callback",
+        scopes: "openid profile",
+        confidential: true
+      )
+    else
+      oauth_application&.destroy
+      AddOns::CleanupAuthProxyJob.perform_later(self) if installed?
     end
   end
 end

--- a/app/models/add_on.rb
+++ b/app/models/add_on.rb
@@ -52,7 +52,7 @@ class AddOn < ApplicationRecord
   }
 
   validates :name, presence: true, format: { with: /\A[a-z0-9-]+\z/, message: "must be lowercase, numbers, and hyphens only" }
-  validates :chart_url, presence: true, format: { with: %r{\A[^/]+/[^/]+\z}, message: "must be in format 'repository/chart'" }
+  validates :chart_url, presence: true, format: { with: %r{\A[^/]+/[^/]+\z}, message: "must be in format 'repository/chart'" }, unless: :oci_repository?
   validates :version, presence: true
   validates :repository_url, presence: true
   after_update_commit do
@@ -71,6 +71,10 @@ class AddOn < ApplicationRecord
   def chart_definition
     charts = K8::Helm::Client::CHARTS["helm"]["charts"]
     charts.find { |chart| chart["chart_url"] == chart_url } || {}
+  end
+
+  def oci_repository?
+    repository_url&.start_with?("oci://")
   end
 
   def repository_name

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -9,6 +9,7 @@
 #  container_registry_url         :string
 #  docker_build_context_directory :string           default("."), not null
 #  dockerfile_path                :string           default("./Dockerfile"), not null
+#  internal                       :boolean          default(FALSE)
 #  managed_namespace              :boolean          default(TRUE)
 #  name                           :string           not null
 #  namespace                      :string           not null
@@ -71,6 +72,9 @@ class Project < ApplicationRecord
   has_one :build_configuration, dependent: :destroy
   has_one :deployment_configuration, dependent: :destroy
   has_one :development_environment_configuration, dependent: :destroy
+  has_one :oauth_application, class_name: "Doorkeeper::Application", dependent: :destroy
+
+  after_save :manage_oauth_application, if: :saved_change_to_internal?
 
   has_one :child_fork, class_name: "ProjectFork", foreign_key: :child_project_id, dependent: :destroy
   has_many :forks, class_name: "ProjectFork", foreign_key: :parent_project_id, dependent: :destroy
@@ -371,5 +375,31 @@ class Project < ApplicationRecord
     end
 
     hash
+  end
+
+  def manage_oauth_application
+    if internal?
+      return if oauth_application.present?
+
+      first_domain = domains.first&.domain_name
+      redirect_uri = if first_domain.present?
+        "https://#{first_domain}/oauth2/callback"
+      else
+        "https://#{name}.canine.sh/oauth2/callback"
+      end
+
+      create_oauth_application!(
+        name: "Auth Proxy: #{name}",
+        redirect_uri: redirect_uri,
+        scopes: "openid profile",
+        confidential: true
+      )
+    else
+      oauth_application&.destroy
+      # Clean up auth proxy K8s resources for all web services
+      services.web_service.each do |service|
+        Services::CleanupAuthProxyJob.perform_later(service) unless service.internal?
+      end
+    end
   end
 end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -8,6 +8,7 @@
 #  container_port          :integer          default(3000)
 #  description             :text
 #  healthcheck_url         :string
+#  internal                :boolean          default(FALSE)
 #  last_health_checked_at  :datetime
 #  name                    :string           not null
 #  pod_yaml                :jsonb
@@ -44,6 +45,7 @@ class Service < ApplicationRecord
 
   has_one :cron_schedule, dependent: :destroy
   has_one :resource_constraint, dependent: :destroy
+  has_one :oauth_application, class_name: "Doorkeeper::Application", dependent: :destroy
 
   validates :cron_schedule, presence: true, if: :cron_job?
   validates :command, presence: true, if: :cron_job?
@@ -53,6 +55,8 @@ class Service < ApplicationRecord
                    uniqueness: { scope: :project_id }
 
   accepts_nested_attributes_for :domains, allow_destroy: true
+
+  after_save :manage_oauth_application, if: :saved_change_to_internal?
 
   def internal_url
     # Kubernetes internal URL
@@ -77,6 +81,18 @@ class Service < ApplicationRecord
     end
   end
 
+  def requires_auth?
+    internal? || project.internal?
+  end
+
+  def effective_oauth_application
+    oauth_application || project.oauth_application
+  end
+
+  def auth_proxy_cookie_secret
+    effective_oauth_application&.secret&.first(32)
+  end
+
   def self.permitted_params(params)
     permitted = params.require(:service).permit(
       :service_type,
@@ -87,6 +103,7 @@ class Service < ApplicationRecord
       :replicas,
       :description,
       :allow_public_networking,
+      :internal,
       :pod_yaml
     )
 
@@ -101,5 +118,28 @@ class Service < ApplicationRecord
     end
 
     permitted
+  end
+
+  private
+
+  def manage_oauth_application
+    if internal?
+      return if oauth_application.present?
+
+      redirect_uri = if auto_domain.present?
+        "https://#{auto_domain}/oauth2/callback"
+      else
+        "https://placeholder.canine.sh/oauth2/callback"
+      end
+
+      create_oauth_application!(
+        name: "Auth Proxy: #{name} (#{project.name})",
+        redirect_uri: redirect_uri,
+        scopes: "openid profile",
+        confidential: true
+      )
+    else
+      oauth_application&.destroy
+    end
   end
 end

--- a/app/services/deployments/helm_deployment_service.rb
+++ b/app/services/deployments/helm_deployment_service.rb
@@ -68,6 +68,9 @@ class Deployments::HelmDeploymentService < Deployments::BaseDeploymentService
     elsif service.web_service?
       @chart_builder << build_resource("Deployment", service)
       @chart_builder << build_resource("Service", service)
+      if service.requires_auth? && service.effective_oauth_application.present?
+        @chart_builder << build_resource("AuthProxy", service)
+      end
       if service.domains.any? && service.allow_public_networking?
         @chart_builder << build_resource("Ingress", service)
       end

--- a/app/services/deployments/legacy_deployment_service.rb
+++ b/app/services/deployments/legacy_deployment_service.rb
@@ -69,6 +69,9 @@ class Deployments::LegacyDeploymentService < Deployments::BaseDeploymentService
     elsif service.web_service?
       apply_resource("Deployment", service)
       apply_resource("Service", service)
+      if service.requires_auth? && service.effective_oauth_application.present?
+        apply_resource("AuthProxy", service)
+      end
       if service.domains.any? && service.allow_public_networking?
         apply_resource("Ingress", service)
       end

--- a/app/services/k8/add_ons/auth_proxy.rb
+++ b/app/services/k8/add_ons/auth_proxy.rb
@@ -1,0 +1,26 @@
+class K8::AddOns::AuthProxy < K8::Base
+  attr_reader :add_on, :endpoint, :port, :domains
+
+  def initialize(add_on, endpoint, port, domains)
+    @add_on = add_on
+    @endpoint = endpoint
+    @port = port
+    @domains = domains
+  end
+
+  def issuer_url
+    Rails.application.credentials.dig(:app, :host) || "https://canine.sh"
+  end
+
+  def client_id
+    add_on.oauth_application&.uid
+  end
+
+  def client_secret
+    add_on.oauth_application&.secret
+  end
+
+  def cookie_secret
+    add_on.auth_proxy_cookie_secret
+  end
+end

--- a/app/services/k8/stateless/auth_proxy.rb
+++ b/app/services/k8/stateless/auth_proxy.rb
@@ -1,0 +1,24 @@
+class K8::Stateless::AuthProxy < K8::Base
+  attr_accessor :service, :project
+
+  def initialize(service)
+    @service = service
+    @project = service.project
+  end
+
+  def issuer_url
+    Rails.application.credentials.dig(:app, :host) || "https://canine.sh"
+  end
+
+  def client_id
+    service.effective_oauth_application&.uid
+  end
+
+  def client_secret
+    service.effective_oauth_application&.secret
+  end
+
+  def cookie_secret
+    service.auth_proxy_cookie_secret
+  end
+end

--- a/app/views/add_ons/edit.html.erb
+++ b/app/views/add_ons/edit.html.erb
@@ -9,6 +9,24 @@
       <% end %>
     </div>
     <div>
+      <h2 class="text-lg font-bold">Authentication</h2>
+      <p class="text-sm text-gray-500 mb-2">
+        Require users to authenticate through Canine before accessing this add-on's endpoints.
+      </p>
+      <%= form_with(model: @add_on) do |form| %>
+        <div class="form-control rounded-lg bg-base-200 p-2 px-4 max-w-sm">
+          <label class="label mt-1">
+            <span class="label-text cursor-pointer">Require authentication (internal add-on)</span>
+            <%= form.check_box :internal, class: "checkbox" %>
+          </label>
+        </div>
+        <span class="label-text-alt">Endpoints with ingresses will require login through Canine before access</span>
+        <div class="form-footer">
+          <%= form.submit "Save", class: "btn btn-primary btn-sm", data: { turbo_submits_with: "Saving..." } %>
+        </div>
+      <% end %>
+    </div>
+    <div>
       <div class="flex items-center justify-between mb-2">
         <h2 class="text-lg font-bold">Configuration</h2>
         <% if @add_on.installed? %>

--- a/app/views/add_ons/helm/_form.html.erb
+++ b/app/views/add_ons/helm/_form.html.erb
@@ -21,6 +21,15 @@
         description: "Provide your own Helm chart repository URL.",
         partial: "add_ons/helm/custom_url_fields",
         locals: { form: form }
+      },
+      {
+        icon: "carbon:container-registry",
+        name: "helm_source_type",
+        label: "OCI Registry",
+        value: "oci_registry",
+        description: "Install from an OCI-compatible container registry.",
+        partial: "add_ons/helm/oci_registry_fields",
+        locals: { form: form }
       }
     ] %>
   </div>

--- a/app/views/add_ons/helm/_oci_registry_fields.html.erb
+++ b/app/views/add_ons/helm/_oci_registry_fields.html.erb
@@ -1,0 +1,25 @@
+<div class="space-y-4" data-controller="add-ons--oci-registry">
+  <div class="form-group">
+    <%= form.label "OCI Registry URL" %>
+    <input type="text"
+        name="oci_url_display"
+        class="input input-bordered w-full max-w-md font-mono text-sm"
+        placeholder="e.g., oci://ghcr.io/danny-avila/librechat-chart/librechat"
+        data-add-ons--oci-registry-target="ociUrl"
+        data-action="input->add-ons--oci-registry#onInput">
+    <label class="label">
+      <span class="label-text-alt">Enter an OCI Helm chart URL</span>
+    </label>
+    <div data-add-ons--oci-registry-target="loading" class="hidden">
+      <div class="flex items-center gap-2 text-sm text-gray-500 mt-2">
+        <span class="loading loading-spinner loading-sm"></span>
+        Fetching available versions...
+      </div>
+    </div>
+    <div data-add-ons--oci-registry-target="error" class="hidden">
+      <div class="alert alert-error text-sm mt-2">
+        <span data-add-ons--oci-registry-target="errorMessage"></span>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -31,6 +31,26 @@
       </div>
     <% end %>
 
+    <div id="authentication">
+      <h2 class="text-2xl font-bold">Authentication</h2>
+      <hr class="mt-3 mb-4 border-t border-base-300" />
+      <p class="text-sm text-gray-500 mb-4">
+        Require users to authenticate through Canine before accessing any web service in this project.
+      </p>
+      <%= form_with(model: @project, class: "space-y-4") do |form| %>
+        <div class="form-control rounded-lg bg-base-200 p-2 px-4 max-w-sm">
+          <label class="label mt-1">
+            <span class="label-text cursor-pointer">Require authentication (internal project)</span>
+            <%= form.check_box :internal, class: "checkbox" %>
+          </label>
+        </div>
+        <span class="label-text-alt">All web services will require login through Canine before access</span>
+        <div class="form-footer">
+          <%= form.submit "Save", class: "btn btn-primary btn-sm", data: { turbo_submits_with: "Saving..." } %>
+        </div>
+      <% end %>
+    </div>
+
     <div id="volumes">
       <h2 class="text-2xl font-bold">Volumes</h2>
       <hr class="mt-3 mb-4 border-t border-base-300" />

--- a/app/views/projects/services/_networking.html.erb
+++ b/app/views/projects/services/_networking.html.erb
@@ -9,6 +9,21 @@
 
     <%= render "projects/services/telepresence_guide", cluster: @project.cluster, url: "http://#{service.internal_url}" %>
   </div>
+  <% if service.requires_auth? %>
+    <div class="mb-6">
+      <h2 class="text-xl font-bold">Authentication</h2>
+      <hr class="mt-3 mb-4 border-t border-base-300" />
+      <div class="alert alert-info">
+        <iconify-icon icon="lucide:shield-check"></iconify-icon>
+        <span>
+          This service requires Canine authentication. Users must log in before accessing it.
+          <% if service.project.internal? && !service.internal? %>
+            <br/><span class="text-xs opacity-75">(Inherited from project settings)</span>
+          <% end %>
+        </span>
+      </div>
+    </div>
+  <% end %>
   <% if service.allow_public_networking? %>
     <div>
       <h2 class="text-xl font-bold">Public Networking</h2>

--- a/app/views/projects/services/_overview.html.erb
+++ b/app/views/projects/services/_overview.html.erb
@@ -35,6 +35,13 @@
             </label>
           </div>
           <span class="label-text-alt">Checking this allows your service to be accessible from the public internet</span>
+          <div class="form-control rounded-lg bg-base-200 p-2 px-4 mt-2">
+            <label class="label mt-1">
+              <span class="label-text cursor-pointer">Require authentication (internal service)</span>
+              <%= form.check_box :internal, class: "checkbox" %>
+            </label>
+          </div>
+          <span class="label-text-alt">Requires users to login through Canine before accessing this service</span>
         <% end %>
         <% if service.web_service? || service.background_service? %>
         <div>

--- a/app/views/projects/services/new.html.erb
+++ b/app/views/projects/services/new.html.erb
@@ -99,6 +99,13 @@
             </label>
           </div>
           <span class="label-text-alt">Checking this allows your service to be accessible from the public internet</span>
+          <div class="form-control rounded-lg bg-base-200 p-2 px-4 max-w-sm mt-2">
+            <label class="label mt-1">
+              <span class="label-text cursor-pointer">Require authentication (internal service)</span>
+              <%= form.check_box :internal, class: "checkbox" %>
+            </label>
+          </div>
+          <span class="label-text-alt">Requires users to login through Canine before accessing this service</span>
         </div>
 
         <div class="card-form hidden card-web_service card-background_service">

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -7,7 +7,7 @@ Doorkeeper.configure do
   access_token_expires_in nil
 
   default_scopes :public
-  optional_scopes :write, :read
+  optional_scopes :write, :read, :openid, :profile
 
   # This sometimes breaks the devise login screen,
   # but in theory should be set due to McpController inheriting from ActionController::API

--- a/config/initializers/doorkeeper_openid_connect.rb
+++ b/config/initializers/doorkeeper_openid_connect.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+Doorkeeper::OpenidConnect.configure do
+  issuer do |_resource_owner, _application, request|
+    request&.base_url || Rails.application.credentials.dig(:app, :host) || "https://canine.sh"
+  end
+
+  signing_key Rails.application.credentials.dig(:oidc, :signing_key) || OpenSSL::PKey::RSA.generate(2048).to_pem
+
+  subject_types_supported [ :public ]
+
+  resource_owner_from_access_token do |access_token|
+    User.find_by(id: access_token.resource_owner_id)
+  end
+
+  auth_time_from_resource_owner do |resource_owner|
+    resource_owner.current_sign_in_at || resource_owner.created_at
+  end
+
+  reauthenticate_resource_owner do |resource_owner, return_to|
+    store_location_for resource_owner, return_to
+    sign_out resource_owner
+    redirect_to new_user_session_url
+  end
+
+  subject do |resource_owner, _application|
+    resource_owner.id
+  end
+
+  expiration 3600
+
+  claims do
+    normal_claim :email, scope: :openid do |resource_owner|
+      resource_owner.email
+    end
+
+    normal_claim :name, scope: :profile, response: %i[id_token user_info] do |resource_owner|
+      resource_owner.name.to_s
+    end
+
+    normal_claim :preferred_username, scope: :profile do |resource_owner|
+      resource_owner.email
+    end
+  end
+end

--- a/config/locales/doorkeeper_openid_connect.en.yml
+++ b/config/locales/doorkeeper_openid_connect.en.yml
@@ -1,0 +1,28 @@
+en:
+  doorkeeper:
+    scopes:
+      openid: 'Authenticate your account'
+      profile: 'View your profile information'
+      email: 'View your email address'
+      address: 'View your physical address'
+      phone: 'View your phone number'
+    errors:
+      messages:
+        login_required: 'The authorization server requires end-user authentication'
+        consent_required: 'The authorization server requires end-user consent'
+        interaction_required: 'The authorization server requires end-user interaction'
+        account_selection_required: 'The authorization server requires end-user account selection'
+    openid_connect:
+      errors:
+        messages:
+          # Configuration error messages
+          resource_owner_from_access_token_not_configured: 'Failure due to Doorkeeper::OpenidConnect.configure.resource_owner_from_access_token missing configuration.'
+          auth_time_from_resource_owner_not_configured: 'Failure due to Doorkeeper::OpenidConnect.configure.auth_time_from_resource_owner missing configuration.'
+          reauthenticate_resource_owner_not_configured: 'Failure due to Doorkeeper::OpenidConnect.configure.reauthenticate_resource_owner missing configuration.'
+          select_account_for_resource_owner_not_configured: 'Failure due to Doorkeeper::OpenidConnect.configure.select_account_for_resource_owner missing configuration.'
+          subject_not_configured: 'ID Token generation failed due to Doorkeeper::OpenidConnect.configure.subject missing configuration.'
+          signing_key_not_configured: 'Doorkeeper::OpenidConnect.configure.signing_key must resolve to at least one key.'
+          issuer_not_configured: 'Doorkeeper::OpenidConnect.configure.issuer must resolve to a non-blank value.'
+          dynamic_client_registration_unauthorized: 'Authorization required for client registration'
+          # ID Token claim error messages
+          missing_required_claim: 'Required ID Token claim `%{claim}` is missing or blank'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,7 @@ Rails.application.routes.draw do
   end
 
   use_doorkeeper
+  use_doorkeeper_openid_connect
 
   # RFC 7591: Dynamic Client Registration Protocol
   post "/oauth/register", to: "oauth_client_registration#create", as: :oauth_register

--- a/db/migrate/20260911170602_create_doorkeeper_openid_connect_tables.rb
+++ b/db/migrate/20260911170602_create_doorkeeper_openid_connect_tables.rb
@@ -1,0 +1,15 @@
+class CreateDoorkeeperOpenidConnectTables < ActiveRecord::Migration[7.2]
+  def change
+    create_table :oauth_openid_requests do |t|
+      t.references :access_grant, null: false, index: true
+      t.string :nonce, null: false
+    end
+
+    add_foreign_key(
+      :oauth_openid_requests,
+      :oauth_access_grants,
+      column: :access_grant_id,
+      on_delete: :cascade
+    )
+  end
+end

--- a/db/migrate/20260911170610_add_internal_to_services.rb
+++ b/db/migrate/20260911170610_add_internal_to_services.rb
@@ -1,0 +1,6 @@
+class AddInternalToServices < ActiveRecord::Migration[7.2]
+  def change
+    add_column :services, :internal, :boolean, default: false
+    add_reference :oauth_applications, :service, foreign_key: true, index: { unique: true }
+  end
+end

--- a/db/migrate/20260911172008_add_internal_to_projects_and_add_ons.rb
+++ b/db/migrate/20260911172008_add_internal_to_projects_and_add_ons.rb
@@ -1,0 +1,8 @@
+class AddInternalToProjectsAndAddOns < ActiveRecord::Migration[7.2]
+  def change
+    add_column :projects, :internal, :boolean, default: false
+    add_column :add_ons, :internal, :boolean, default: false
+    add_reference :oauth_applications, :project, foreign_key: true, index: { unique: true }, null: true
+    add_reference :oauth_applications, :add_on, foreign_key: true, index: { unique: true }, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_08_19_000000) do
+ActiveRecord::Schema[7.2].define(version: 2026_09_11_172008) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -84,6 +84,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_19_000000) do
     t.string "version", null: false
     t.string "repository_url", null: false
     t.string "artifact_hub_package_id"
+    t.boolean "internal", default: false
     t.index ["cluster_id", "name"], name: "index_add_ons_on_cluster_id_and_name", unique: true
     t.index ["cluster_id"], name: "index_add_ons_on_cluster_id"
     t.index ["name"], name: "index_add_ons_on_name"
@@ -549,7 +550,19 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_19_000000) do
     t.boolean "confidential", default: true, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "service_id"
+    t.bigint "project_id"
+    t.bigint "add_on_id"
+    t.index ["add_on_id"], name: "index_oauth_applications_on_add_on_id", unique: true
+    t.index ["project_id"], name: "index_oauth_applications_on_project_id", unique: true
+    t.index ["service_id"], name: "index_oauth_applications_on_service_id", unique: true
     t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
+  end
+
+  create_table "oauth_openid_requests", force: :cascade do |t|
+    t.bigint "access_grant_id", null: false
+    t.string "nonce", null: false
+    t.index ["access_grant_id"], name: "index_oauth_openid_requests_on_access_grant_id"
   end
 
   create_table "oidc_configurations", force: :cascade do |t|
@@ -626,6 +639,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_19_000000) do
     t.bigint "current_deployment_id"
     t.string "repository_base_url"
     t.integer "provider_type", default: 0, null: false
+    t.boolean "internal", default: false
     t.index ["cluster_id"], name: "index_projects_on_cluster_id"
     t.index ["current_deployment_id"], name: "index_projects_on_current_deployment_id"
     t.index ["name"], name: "index_projects_on_name"
@@ -697,6 +711,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_19_000000) do
     t.datetime "updated_at", null: false
     t.text "description"
     t.jsonb "pod_yaml"
+    t.boolean "internal", default: false
     t.index ["project_id", "name"], name: "index_services_on_project_id_and_name", unique: true
   end
 
@@ -851,6 +866,10 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_19_000000) do
   add_foreign_key "oauth_access_grants", "users", column: "resource_owner_id"
   add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"
   add_foreign_key "oauth_access_tokens", "users", column: "resource_owner_id"
+  add_foreign_key "oauth_applications", "add_ons"
+  add_foreign_key "oauth_applications", "projects"
+  add_foreign_key "oauth_applications", "services"
+  add_foreign_key "oauth_openid_requests", "oauth_access_grants", column: "access_grant_id", on_delete: :cascade
   add_foreign_key "project_add_ons", "add_ons"
   add_foreign_key "project_add_ons", "projects"
   add_foreign_key "project_credential_providers", "projects"

--- a/resources/k8/add_ons/auth_proxy.yaml
+++ b/resources/k8/add_ons/auth_proxy.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: <%= endpoint.metadata.name %>-auth-proxy
+  namespace: <%= add_on.name %>
+  labels:
+    caninemanaged: 'auth-proxy'
+    app: <%= endpoint.metadata.name %>-auth-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: <%= endpoint.metadata.name %>-auth-proxy
+  template:
+    metadata:
+      labels:
+        app: <%= endpoint.metadata.name %>-auth-proxy
+    spec:
+      containers:
+      - name: oauth2-proxy
+        image: quay.io/oauth2-proxy/oauth2-proxy:v7.7.1
+        args:
+        - --provider=oidc
+        - --oidc-issuer-url=<%= issuer_url %>
+        - --client-id=<%= client_id %>
+        - --client-secret=<%= client_secret %>
+        - --cookie-secret=<%= cookie_secret %>
+        - --cookie-secure=true
+        - --upstream=http://<%= endpoint.metadata.name %>.<%= add_on.name %>.svc.cluster.local:<%= port %>
+        - --http-address=0.0.0.0:4180
+        - --redirect-url=https://<%= domains.first %>/oauth2/callback
+        - --email-domain=*
+        - --scope=openid profile
+        - --skip-provider-button=true
+        ports:
+        - containerPort: 4180
+          name: http
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: 4180
+          initialDelaySeconds: 10
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /ping
+            port: 4180
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        resources:
+          requests:
+            cpu: "10m"
+            memory: "32Mi"
+          limits:
+            cpu: "100m"
+            memory: "64Mi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: <%= endpoint.metadata.name %>-auth-proxy
+  namespace: <%= add_on.name %>
+  labels:
+    caninemanaged: 'auth-proxy'
+spec:
+  selector:
+    app: <%= endpoint.metadata.name %>-auth-proxy
+  ports:
+  - port: 80
+    targetPort: 4180
+    protocol: TCP

--- a/resources/k8/add_ons/ingress.yaml
+++ b/resources/k8/add_ons/ingress.yaml
@@ -24,7 +24,13 @@ spec:
         path: "/"
         backend:
           service:
+            <% if add_on.internal? %>
+            name: <%= endpoint.metadata.name %>-auth-proxy
+            port:
+              number: 80
+            <% else %>
             name: <%= endpoint.metadata.name %>
             port:
               number: <%= port %>
+            <% end %>
   <% end %>

--- a/resources/k8/stateless/auth_proxy.yaml
+++ b/resources/k8/stateless/auth_proxy.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: <%= service.name %>-auth-proxy
+  namespace: <%= project.namespace %>
+  labels:
+    caninemanaged: 'auth-proxy'
+    app: <%= service.name %>-auth-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: <%= service.name %>-auth-proxy
+  template:
+    metadata:
+      labels:
+        app: <%= service.name %>-auth-proxy
+    spec:
+      containers:
+      - name: oauth2-proxy
+        image: quay.io/oauth2-proxy/oauth2-proxy:v7.7.1
+        args:
+        - --provider=oidc
+        - --oidc-issuer-url=<%= issuer_url %>
+        - --client-id=<%= client_id %>
+        - --client-secret=<%= client_secret %>
+        - --cookie-secret=<%= cookie_secret %>
+        - --cookie-secure=true
+        - --upstream=http://<%= service.name %>-service.<%= project.namespace %>.svc.cluster.local:80
+        - --http-address=0.0.0.0:4180
+        - --redirect-url=https://<%= service.auto_domain %>/oauth2/callback
+        - --email-domain=*
+        - --scope=openid profile
+        - --skip-provider-button=true
+        ports:
+        - containerPort: 4180
+          name: http
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: 4180
+          initialDelaySeconds: 10
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /ping
+            port: 4180
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        resources:
+          requests:
+            cpu: "10m"
+            memory: "32Mi"
+          limits:
+            cpu: "100m"
+            memory: "64Mi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: <%= service.name %>-auth-proxy
+  namespace: <%= project.namespace %>
+  labels:
+    caninemanaged: 'auth-proxy'
+spec:
+  selector:
+    app: <%= service.name %>-auth-proxy
+  ports:
+  - port: 80
+    targetPort: 4180
+    protocol: TCP

--- a/resources/k8/stateless/ingress.yaml
+++ b/resources/k8/stateless/ingress.yaml
@@ -27,7 +27,11 @@ spec:
         path: "/"
         backend:
           service:
+            <% if service.requires_auth? %>
+            name: <%= service.name %>-auth-proxy
+            <% else %>
             name: <%= service.name %>-service
+            <% end %>
             port:
               number: 80
   <% end %>

--- a/spec/factories/add_ons.rb
+++ b/spec/factories/add_ons.rb
@@ -5,6 +5,7 @@
 #  id                      :bigint           not null, primary key
 #  chart_type              :string
 #  chart_url               :string
+#  internal                :boolean          default(FALSE)
 #  managed_namespace       :boolean          default(TRUE)
 #  metadata                :jsonb
 #  name                    :string           not null

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -9,6 +9,7 @@
 #  container_registry_url         :string
 #  docker_build_context_directory :string           default("."), not null
 #  dockerfile_path                :string           default("./Dockerfile"), not null
+#  internal                       :boolean          default(FALSE)
 #  managed_namespace              :boolean          default(TRUE)
 #  name                           :string           not null
 #  namespace                      :string           not null

--- a/spec/factories/services.rb
+++ b/spec/factories/services.rb
@@ -8,6 +8,7 @@
 #  container_port          :integer          default(3000)
 #  description             :text
 #  healthcheck_url         :string
+#  internal                :boolean          default(FALSE)
 #  last_health_checked_at  :datetime
 #  name                    :string           not null
 #  pod_yaml                :jsonb

--- a/spec/models/add_on_spec.rb
+++ b/spec/models/add_on_spec.rb
@@ -5,6 +5,7 @@
 #  id                      :bigint           not null, primary key
 #  chart_type              :string
 #  chart_url               :string
+#  internal                :boolean          default(FALSE)
 #  managed_namespace       :boolean          default(TRUE)
 #  metadata                :jsonb
 #  name                    :string           not null

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -9,6 +9,7 @@
 #  container_registry_url         :string
 #  docker_build_context_directory :string           default("."), not null
 #  dockerfile_path                :string           default("./Dockerfile"), not null
+#  internal                       :boolean          default(FALSE)
 #  managed_namespace              :boolean          default(TRUE)
 #  name                           :string           not null
 #  namespace                      :string           not null

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -8,6 +8,7 @@
 #  container_port          :integer          default(3000)
 #  description             :text
 #  healthcheck_url         :string
+#  internal                :boolean          default(FALSE)
 #  last_health_checked_at  :datetime
 #  name                    :string           not null
 #  pod_yaml                :jsonb


### PR DESCRIPTION
## Summary
- Restores all changes that were reverted from main on 2026-09-19
- Includes internal auth proxy, SSO/OAuth/OIDC, endpoint actions refactor, and related features
- These changes were previously in main but removed during the revert to `c5c57e3`
- PRs #734, #740, and #743 were kept during the revert and are already on main

## Original PRs included
- #736 - Internal auth proxy
- #738 - Add-on endpoint actions refactor
- #744 - Derive internal from OAuth app
- #746 - Fix SSO redirect URI
- #748 - Fix SSO HTTPS scheme
- #749 - Fix MCP OAuth metadata route
- #750 - Normalize APP_HOST URL
- #751 - OpenID Connect registration endpoint

## Test plan
- [ ] Verify internal auth proxy functionality
- [ ] Verify SSO/OAuth flows work correctly
- [ ] Run full test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)